### PR TITLE
For #30275, checks engine version is compatible with new desktop

### DIFF
--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -74,6 +74,20 @@ class UpgradeCoreError(ShotgunDesktopError):
         )
 
 
+class UpgradeEngineError(ShotgunDesktopError):
+    """
+    This exception notifies the catcher that the site's desktop engine needs to be upgraded in order
+    to use this version of the Desktop installer.
+    """
+    def __init__(self, reason, toolkit_path):
+        """Constructor"""
+        ShotgunDesktopError.__init__(
+            self,
+            "%s Please upgrade your site engine by running:\n\n%s updates site" %
+            (reason, os.path.join(toolkit_path, "tank.bat" if sys.platform == "win32" else "tank"))
+        )
+
+
 class ToolkitDisabledError(ShotgunDesktopError):
     """
     This exception notifies the catcher that Toolkit has not been enabled by the user on the site.

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -35,18 +35,19 @@ from shotgun_desktop.initialization import initialize, does_pipeline_configurati
 from shotgun_desktop import authenticator
 from shotgun_desktop.upgrade_startup import upgrade_startup
 from shotgun_desktop.location import get_location
+from distutils.version import LooseVersion
 
 from shotgun_desktop.ui import resources_rc
 import shutil
 
-from shotgun_desktop.errors import (ShotgunDesktopError, RequestRestartException,
+from shotgun_desktop.errors import (ShotgunDesktopError, RequestRestartException, UpgradeEngineError,
                                     ToolkitDisabledError, UpdatePermissionsError, UpgradeCoreError,
                                     InvalidPipelineConfiguration, UnexpectedConfigFound)
 
 RESET_SITE_ARG = "--reset-site"
 
 
-def __supports_authentication_module(sgtk):
+def __toolkit_supports_authentication_module(sgtk):
     """
     Tests if the given Toolkit API supports the shotgun_authentication module.
 
@@ -56,6 +57,18 @@ def __supports_authentication_module(sgtk):
     """
     # if the authentication module is not supported, this method won't be present on the core.
     return hasattr(sgtk, "set_authenticated_user")
+
+
+def __desktop_engine_supports_authentication_module(engine):
+    """
+    Tests if the engine supports the login based authentication. All versions above 2.0.0 supports
+    login based authentication.
+
+    :param engine: The desktop engine to test.
+
+    :returns: True if the engine supports the authentication module, False otherwise.
+    """
+    return LooseVersion(engine.version) >= "v2.0.0"
 
 
 def __supports_pipeline_configuration_upgrade(pipeline_configuration):
@@ -122,7 +135,7 @@ def __initialize_sgtk_authentication(sgtk, app_bootstrap):
     """
 
     # If the version of Toolkit supports the new authentication mechanism
-    if __supports_authentication_module(sgtk):
+    if __toolkit_supports_authentication_module(sgtk):
         # import authentication
         from tank_vendor import shotgun_authentication
         # Add the module to the log file.
@@ -547,6 +560,11 @@ def __launch_app(app, splash, connection, app_bootstrap):
         updates.set_logger(logger)
         updates.execute({})
 
+    if not __toolkit_supports_authentication_module(sgtk):
+        raise UpgradeCoreError(
+            "This version of the Shotgun Desktop only supports core 0.16.4 and higher.",
+            default_site_config
+        )
 
     # initialize the tk-desktop engine for an empty context
     splash.set_message("Starting desktop engine.")
@@ -554,6 +572,12 @@ def __launch_app(app, splash, connection, app_bootstrap):
 
     ctx = tk.context_empty()
     engine = sgtk.platform.start_engine("tk-desktop", tk, ctx)
+
+    if not __desktop_engine_supports_authentication_module(engine):
+        raise UpgradeEngineError(
+            "This version of the Shotgun Desktop only supports tk-desktop engine 2.0.0 and higher.",
+            default_site_config
+        )
 
     # engine will take over logging
     app_bootstrap.tear_down_logging()
@@ -563,12 +587,6 @@ def __launch_app(app, splash, connection, app_bootstrap):
         os.environ["PYTHONPATH"] = os.environ["SGTK_DESKTOP_ORIGINAL_PYTHONPATH"]
     if "SGTK_DESKTOP_ORIGINAL_PYTHONHOME" in os.environ:
         os.environ["PYTHONHOME"] = os.environ["SGTK_DESKTOP_ORIGINAL_PYTHONHOME"]
-
-    if not __supports_authentication_module(sgtk):
-        raise UpgradeCoreError(
-            "This version of the Shotgun Desktop only supports core 0.16.4 and higher. ",
-            default_site_config
-        )
 
     # and run the engine
     logger.debug("Running tk-desktop")


### PR DESCRIPTION
Tells the user to upgrade the desktop engine if the version is lower than 2.0.0
