### PR TITLE
For #30835, move Desktop's config.ini ouf of the bundle

### DIFF
--- a/python/shotgun_desktop/settings.py
+++ b/python/shotgun_desktop/settings.py
@@ -72,7 +72,7 @@ class Settings(object):
     def _get_config_location(self, bootstrap):
         """
         Retrieves the location of the config.ini file. It will first look inside
-        the user folder, then look at the  SGTK_DEFAULT_CONFIG_LOCATION environment
+        the user folder, then look at the  SGTK_DESKTOP_CONFIG_LOCATION environment
         variable and finally in the installation folder.
 
         :param bootstrap: The application bootstrap.
@@ -85,7 +85,7 @@ class Settings(object):
             return location
 
         return os.environ.get(
-            "SGTK_DEFAULT_CONFIG_LOCATION",
+            "SGTK_DESKTOP_CONFIG_LOCATION",
             self._get_install_dir_config_location(bootstrap)
         )
 


### PR DESCRIPTION
config.ini is now loaded from the desktop's configuration directory inside the user folder (On Mac, that's ~/Library/Caches/Shotgun/desktop/config/config.ini). If it is not found, SGTK_DEFAULT_CONFIG_LOCATION is used. Finally, we look into the application installation folder.
