### PR TITLE
For #31678, fix login screen flickering on Cmd-Q

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -317,9 +317,11 @@ class SystrayEventLoop(QtCore.QEventLoop):
         """
         Execute the local event loop. If CmdQ was hit in the past, it will be handled just as if the
         user had picked the Quit menu.
+
+        :returns: The exit code for the loop.
         """
         code = QtCore.QEventLoop.exec_(self)
-        # CmdQ was hit before.
+        # Somebody requested the app to close.
         if code == -1:
             return self.CLOSE_APP
         else:

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -321,11 +321,13 @@ class SystrayEventLoop(QtCore.QEventLoop):
         :returns: The exit code for the loop.
         """
         code = QtCore.QEventLoop.exec_(self)
-        # Somebody requested the app to close.
+        # Somebody requested the app to close, so pretend the close menu was picked.
         if code == -1:
             return self.CLOSE_APP
-        else:
+        elif code in [self.CLOSE_APP, self.LOGIN]:
             return code
+        else:
+            raise Exception("Unexpected return code in local event loop: %s" % code)
 
 
 def __run_with_systray():


### PR DESCRIPTION
Hitting Cmd-Q on the login screen would put every event loop created in the quitNow state, which returns -1. We're now filtering exec_()'s return value so that -1 is now treated as if the user picked Quit in the tray menu.