### PR TITLE
For #Ryan, ask for full info when session is expired.

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -381,7 +381,13 @@ def __do_login(splash, shotgun_authentication, shotgun_authenticator, app_bootst
 
     logger.debug("Retrieving credentials")
     try:
+        # Get the current user
         user = shotgun_authenticator.get_user()
+        # If the current user's credentials are expired.
+        if user.are_credentials_expired():
+            # Clear them and ask them again.
+            shotgun_authenticator.clear_default_user()
+            user = shotgun_authenticator.get_user()
     except shotgun_authentication.AuthenticationCancelled:
         return None
     else:


### PR DESCRIPTION
When the Desktop starts, it checks to see if there is a current user. If there is a current user, regardless of whether the session id is still valid or not we're launching the Desktop with it. This means that further down if the session is expired we're going to be asked for our credentials.

Now, if the session is expired, we clear the cache and ask for a user again. This will prompt for the full set of credentials and site.