### PR TITLE
For #35431, fixed error reporting from bootstrapping thread

### DIFF
--- a/python/shotgun_desktop/initialization/shotgun.py
+++ b/python/shotgun_desktop/initialization/shotgun.py
@@ -16,6 +16,9 @@ from shotgun_api3 import Shotgun
 
 from . import constants
 from distutils.version import LooseVersion
+from ..logger import get_logger
+
+logger = get_logger("initialization.shotgun")
 
 
 def get_server_version(connection):
@@ -127,7 +130,8 @@ def get_app_store_credentials(connection, proxy):
             "ApiUser",
             [["firstname", "is", script]],
             fields=["type", "firstname", "id", "salted_password"])
-    except Exception:
+    except:
+        logger.exception("Something went wrong while connecting to the App Store:")
         return None
 
     return app_store_script

--- a/python/shotgun_desktop/logger.py
+++ b/python/shotgun_desktop/logger.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+import logging
+
+def get_logger(name=None):
+    """
+    Returns a logger named after the name parameter.
+
+    :param name: name of the logger. Can be None.
+
+    :returns: A Python logger named tk-desktop.<name>
+    """
+    if name:
+        return logging.getLogger("tk-desktop.%s" % name)
+    else:
+        return logging.getLogger("tk-desktop")

--- a/python/shotgun_desktop/settings.py
+++ b/python/shotgun_desktop/settings.py
@@ -27,6 +27,7 @@ class Settings(object):
     default_login=login
     default_site=site.shotgunstudio.com
     http_proxy=http://www.someproxy.com:3128
+    app_store_http_proxy=http://www.someproxy.com:3128
     [BrowserIntegration]
     enabled=1
     """
@@ -110,7 +111,7 @@ class Settings(object):
         logger.info("Default site: %s" % self.default_site)
         logger.info("Default proxy: %s" % self._get_filtered_proxy(self.default_http_proxy))
         proxy = self._get_filtered_proxy(self.default_app_store_http_proxy)
-        logger.info("Default app store proxy: %s" % "<not set>" if proxy is None else proxy)
+        logger.info("Default app store proxy: %s" % ("<not set>" if proxy is None else proxy))
         logger.info("Default login: %s" % self.default_login)
         logger.info("Integration enabled: %s" % self.integration_enabled)
 


### PR DESCRIPTION
Errors were simply ignored from the bootstrap thread. If anything went wrong, we'd get the dreaded
```
TankError: Cannot resolve the core configuration from the location of the Sgtk Code!
This can happen if you try to move or symlink the Sgtk API. The Sgtk API is currently
picked up from 
/Applications/Shotgun.app/Contents/Resources/Python/tk-framework-desktopstartup/python/tk-core/python/tank/util
which is an invalid location.
```

We're now correctly catching the error from the exception and forwarding it back to the main thread when the thread completes.

There was also a bit of cleanup for loggers and the log file.