### PR TITLE
For #36848, desktop with 0.18

### DIFF
--- a/python/shotgun_desktop/initialization/initialize.py
+++ b/python/shotgun_desktop/initialization/initialize.py
@@ -10,17 +10,17 @@
 
 import os
 import sys
-import logging
 import tempfile
 
 from . import install
 from . import shotgun
 from .. import paths
+from .. logger import get_logger
 
 
 def initialize(splash, connection, app_store_http_proxy):
     """ initialize toolkit for this computer for a single site """
-    logger = logging.getLogger("tk-desktop.initialization")
+    logger = get_logger("initialization")
 
     # grab the paths that will be used during the install
     temp_dir = tempfile.mkdtemp(prefix="tk-desktop")

--- a/python/shotgun_desktop/initialization/install.py
+++ b/python/shotgun_desktop/initialization/install.py
@@ -21,8 +21,6 @@ from distutils.version import LooseVersion
 
 from PySide import QtCore
 
-from shotgun_api3 import Shotgun
-
 from .. import utils
 from . import constants
 from . import shotgun
@@ -224,6 +222,8 @@ class InstallThread(QtCore.QThread):
         # download latest core from the app store
         sg_studio_version = ".".join([str(x) for x in self._connection.server_info["version"]])
 
+        # Lazy-init since at import type it won't be defined.
+        from shotgun_api3 import Shotgun
         sg_app_store = Shotgun(
             constants.SGTK_APP_STORE, self._app_store_script, self._app_store_key,
             http_proxy=self._actual_app_store_http_proxy

--- a/python/shotgun_desktop/initialization/install.py
+++ b/python/shotgun_desktop/initialization/install.py
@@ -13,7 +13,6 @@ import sys
 import uuid
 import errno
 import shutil
-import logging
 import tempfile
 import traceback
 

--- a/python/shotgun_desktop/initialization/shotgun.py
+++ b/python/shotgun_desktop/initialization/shotgun.py
@@ -12,8 +12,6 @@ import json
 import urllib
 import urllib2
 
-from shotgun_api3 import Shotgun
-
 from . import constants
 from distutils.version import LooseVersion
 from ..logger import get_logger
@@ -118,11 +116,15 @@ def get_or_create_script(connection):
 
 
 def get_app_store_credentials(connection, proxy):
-    """ Return the validated script for this site to connect to the app store """
+    """
+    Return the validated script for this site to connect to the app store.
+    """
     (script, key) = __get_app_store_key(connection)
 
     # connect to the app store
     try:
+        # Lazy-init since at import type it won't be defined.
+        from shotgun_api3 import Shotgun
         sg_app_store = Shotgun(constants.SGTK_APP_STORE, script, key, http_proxy=proxy)
 
         # pull down the full script information

--- a/python/shotgun_desktop/logger.py
+++ b/python/shotgun_desktop/logger.py
@@ -20,6 +20,6 @@ def get_logger(name=None):
     :returns: A Python logger named tk-desktop.<name>
     """
     if name:
-        return logging.getLogger("tk-desktop.%s" % name)
+        return logging.getLogger("sgtk.ext.tk-framework-desktopstartup.%s" % name)
     else:
-        return logging.getLogger("tk-desktop")
+        return logging.getLogger("sgtk.ext.tk-framework-desktopstartup")

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -11,9 +11,9 @@
 import os
 import sys
 import urlparse
-import logging
+from .logger import get_logger
 
-logger = logging.getLogger("tk-desktop.paths")
+logger = get_logger("paths")
 
 def get_python_path():
     """ returns the path to the default python interpreter """

--- a/python/shotgun_desktop/settings.py
+++ b/python/shotgun_desktop/settings.py
@@ -11,9 +11,9 @@
 import sys
 import os
 import ConfigParser
-import logging
+from .logger import get_logger
 
-logger = logging.getLogger("tk-desktop.settings")
+logger = get_logger("settings")
 
 
 class Settings(object):

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -21,22 +21,6 @@ import traceback
 import shotgun_desktop.splash
 from .logger import get_logger
 
-logger = get_logger()
-logger.info("------------------ Desktop Engine Startup ------------------")
-
-# Add shotgun_api3 bundled with tk-core to the path.
-shotgun_api3_path = os.path.normpath(os.path.join(os.path.split(__file__)[0], "..", "tk-core", "python", "tank_vendor"))
-sys.path.insert(0, shotgun_api3_path)
-logger.info("Using shotgun_api3 from '%s'" % shotgun_api3_path)
-# Add the Shotgun Desktop Server source to the Python path
-if "SGTK_DESKTOP_SERVER_LOCATION" in os.environ:
-    desktop_server_root = os.environ["SGTK_DESKTOP_SERVER_LOCATION"]
-else:
-    desktop_server_root = os.path.normpath(os.path.join(os.path.split(__file__)[0], "..", "server"))
-sys.path.insert(0, os.path.join(desktop_server_root, "python"))
-logger.info("Using browser integration from '%s'" % desktop_server_root)
-
-
 # now proceed with non builtin imports
 from PySide import QtCore, QtGui
 
@@ -56,6 +40,8 @@ import shutil
 from shotgun_desktop.errors import (ShotgunDesktopError, RequestRestartException, UpgradeEngineError,
                                     ToolkitDisabledError, UpdatePermissionsError, UpgradeCoreError,
                                     InvalidPipelineConfiguration, UnexpectedConfigFound)
+
+logger = get_logger()
 
 
 def __is_64bit_python():
@@ -1137,10 +1123,26 @@ def main(**kwargs):
 
     :returns: Error code for the process.
     """
-    logger.debug("Running main from %s" % __file__)
+
     app_bootstrap = _BootstrapProxy(kwargs["app_bootstrap"])
     app_bootstrap.add_logger_to_logfile(logger)
 
+    logger.info("------------------ Desktop Engine Startup ------------------")
+    logger.debug("Running main from %s" % __file__)
+
+    # Add shotgun_api3 bundled with tk-core to the path.
+    shotgun_api3_path = os.path.normpath(os.path.join(os.path.split(__file__)[0], "..", "tk-core", "python", "tank_vendor"))
+    sys.path.insert(0, shotgun_api3_path)
+    logger.info("Using shotgun_api3 from '%s'" % shotgun_api3_path)
+    # Add the Shotgun Desktop Server source to the Python path
+    if "SGTK_DESKTOP_SERVER_LOCATION" in os.environ:
+        desktop_server_root = os.environ["SGTK_DESKTOP_SERVER_LOCATION"]
+    else:
+        desktop_server_root = os.path.normpath(os.path.join(os.path.split(__file__)[0], "..", "server"))
+    sys.path.insert(0, os.path.join(desktop_server_root, "python"))
+    logger.info("Using browser integration from '%s'" % desktop_server_root)
+
+    # Reading user settings from disk.
     settings = Settings(app_bootstrap)
     settings.dump(logger)
 

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -18,10 +18,10 @@ import struct
 import traceback
 
 # initialize logging
-import logging
 import shotgun_desktop.splash
+from .logger import get_logger
 
-logger = logging.getLogger("tk-desktop.startup")
+logger = get_logger()
 logger.info("------------------ Desktop Engine Startup ------------------")
 
 # Add shotgun_api3 bundled with tk-core to the path.
@@ -86,10 +86,24 @@ def __desktop_engine_supports_authentication_module(engine):
 
     :returns: True if the engine supports the authentication module, False otherwise.
     """
-    if engine.version.lower() == 'undefined':
-        logger.warning("The version of the tk-desktop engine is undefined.")
+    if engine.version.lower() == "undefined":
+        logger.warning("The version of the tk-desktop engine is undefined. Assuming authentication is supported.")
         return True
     return LooseVersion(engine.version) >= "v2.0.0"
+
+
+def __desktop_engine_uses_core_logging(engine):
+    """
+    Tests if the engine uses the logging code from core. All versions above 3.0.0 suppor this feature.
+
+    :param engine: The desktop engine to test.
+
+    :returns: True if the engine supports logging using core, False otherwise.
+    """
+    if engine.version.lower() == "undefined":
+        logger.warning("The version of the tk-desktop engine is undefined. Assuming logging is supported.")
+        return True
+    return LooseVersion(engine.version) >= "v3.0.0"
 
 
 def __supports_pipeline_configuration_upgrade(pipeline_configuration):
@@ -146,7 +160,14 @@ def is_toolkit_already_configured(site_configuration_path):
     return False
 
 
-def __initialize_sgtk_authentication(sgtk, app_bootstrap):
+def __is_logging_supported(sgtk):
+    """
+    :returns: True if LogManager.initialize_base_file_handler_from_path exists, False otherwise.
+    """
+    return hasattr(sgtk, "LogManager") and hasattr(sgtk.LogManager, "initialize_base_file_handler_from_path")
+
+
+def __initialize_sgtk(sgtk, app_bootstrap):
     """
     Sets the authenticated user if available. Also registers the authentication module's
     logger with the Desktop's.
@@ -155,12 +176,30 @@ def __initialize_sgtk_authentication(sgtk, app_bootstrap):
     :param app_bootstrap: The application bootstrap instance.
     """
 
+    # if we're importing a core that supports logging, tear down our logging
+    # to use the new one. The initial release of 0.18 didn't include the initialize_base_file_handler_from_path,
+    # so test for that as well.
+    if __is_logging_supported(sgtk):
+        logger.debug("Found a core that supports logging.")
+        # Tear down the logging
+        app_bootstrap.tear_down_logging()
+
+        sgtk.LogManager().initialize_base_file_handler_from_path(
+            app_bootstrap.get_logfile_location()
+        )
+        # Builtin core doesn't log debug messages by default, but the Shotgun Desktop does,
+        # so turn it on.
+        sgtk.LogManager().global_debug = True
+        logger.debug("Switch to core-based logging completed.")
+
     # If the version of Toolkit supports the new authentication mechanism
     if __toolkit_supports_authentication_module(sgtk):
         # import authentication
         from tank_vendor import shotgun_authentication
-        # Add the module to the log file.
-        app_bootstrap.add_logger_to_logfile(shotgun_authentication.get_logger())
+
+        # Add the module to the log file, only if core isn't already logging for us.
+        if not __is_logging_supported(sgtk):
+            app_bootstrap.add_logger_to_logfile(shotgun_authentication.get_logger())
 
         dm = sgtk.util.CoreDefaultsManager()
         sg_auth = shotgun_authentication.ShotgunAuthenticator(dm)
@@ -182,7 +221,7 @@ def __get_initialized_sgtk(path, app_bootstrap):
     :returns: The imported sgtk module.
     """
     sgtk = __import_sgtk_from_path(path)
-    __initialize_sgtk_authentication(sgtk, app_bootstrap)
+    __initialize_sgtk(sgtk, app_bootstrap)
     return sgtk
 
 
@@ -534,7 +573,7 @@ def __launch_app(app, splash, connection, app_bootstrap, server, settings):
     else:
         # Toolkit was imported, we need to initialize it now.
         if toolkit_imported:
-            __initialize_sgtk_authentication(sgtk, app_bootstrap)
+            __initialize_sgtk(sgtk, app_bootstrap)
 
     if not toolkit_imported:
         # sgtk not available. initialize core
@@ -740,7 +779,21 @@ def __launch_app(app, splash, connection, app_bootstrap, server, settings):
     app.processEvents()
 
     ctx = tk.context_empty()
+
+    # We're about to start the engine and at this point the Desktop should use be using the logging
+    # behavior of the engine, so disable global logging and let the engine decide if it should be
+    # done.
+    if __is_logging_supported(sgtk):
+        logger.info("We're about to launch the engine, turning off global debug.")
+        sgtk.LogManager().global_debug = False
+
     engine = sgtk.platform.start_engine("tk-desktop", tk, ctx)
+
+    # If the engine that just started up is using the legacy core logging code and our core has
+    # logging, tear it down.
+    if not __desktop_engine_uses_core_logging(engine) and __is_logging_supported(sgtk):
+        logger.info("Engine doesn't use core-based logging, so tearing-down core based logging.")
+        sgtk.LogManager().uninitialize_base_file_handler()
 
     if not __desktop_engine_supports_authentication_module(engine):
         raise UpgradeEngineError(
@@ -748,7 +801,9 @@ def __launch_app(app, splash, connection, app_bootstrap, server, settings):
             default_site_config
         )
 
-    # engine will take over logging
+    # engine will take over logging. Note that when using core 0.18 this will have already been torn down
+    # and will be a no-op, but for previous versions of core, this is where we stop using the bootstrap's
+    # logging and start using the engine's.
     app_bootstrap.tear_down_logging()
 
     # reset PYTHONPATH and PYTHONHOME if they were overridden by the application
@@ -1084,6 +1139,7 @@ def main(**kwargs):
     """
     logger.debug("Running main from %s" % __file__)
     app_bootstrap = _BootstrapProxy(kwargs["app_bootstrap"])
+    app_bootstrap.add_logger_to_logfile(logger)
 
     settings = Settings(app_bootstrap)
     settings.dump(logger)

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -12,6 +12,7 @@ import os
 from distutils.version import LooseVersion
 from shotgun_desktop.location import get_location, write_location
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
+from .logger import get_logger
 
 import httplib
 

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -9,14 +9,13 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import logging
 from distutils.version import LooseVersion
 from shotgun_desktop.location import get_location, write_location
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
 
 import httplib
 
-logger = logging.getLogger("tk-desktop.startup")
+logger = get_logger("upgrade_startup")
 
 
 def _supports_get_from_location_and_paths(sgtk):


### PR DESCRIPTION
In order to have the best logging experience, we'll first make sure that when we import a 0.18 core or greater we switch automatically to its own logging framework. This happens inside `__initialize_sgtk`. We'll also set the global_debug flag so that debug messages are still logged, just like it used to.

The second step is making sure that after the engine is started that the core-based logging is still required. Because a client could have upgraded core but not the engine, we need to tear down core based logging if the engine is too old. Ideally we wouldn't have switched to core based logging earlier, but we couldn't know from the start if the engine would use it.

NOTE: The first commit is house-cleaning, so you can skip it and jump directly to the second one, which is where I've added comments.