### PR TITLE
For #39874, handle missing appstore key in a cleaner fashion

### DIFF
--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -40,10 +40,9 @@ class ShotgunDesktopError(Exception):
         """
 
         if support_required:
-            support_message = "Please contact support at {0} to resolve this issue.".format(self._SUPPORT_EMAIL)
+            support_message = "Please contact {0} to resolve this issue.".format(self._SUPPORT_EMAIL)
         else:
-            support_message = ("If you need help with this issue, please contact our support team at "
-                               "{0}.").format(self._SUPPORT_EMAIL)
+            support_message = ("If you need help with this issue, please contact {0}.").format(self._SUPPORT_EMAIL)
         Exception.__init__(
             self,
             "%s\n\n%s" % (message, support_message)

--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -30,13 +30,23 @@ class ShotgunDesktopError(Exception):
     """
     Common base class for Shotgun Desktop errors.
     """
-    def __init__(self, message):
-        """Constructor"""
+    _SUPPORT_EMAIL = "support@shotgunsoftware.com"
+
+    def __init__(self, message, support_required=False):
+        """
+        :param message: Error message to display.
+        :param optional_support: Indicates if the epilog should mention that contacting support is optional
+             or required to resolve this issue.
+        """
+
+        if support_required:
+            support_message = "Please contact support at {0} to resolve this issue.".format(self._SUPPORT_EMAIL)
+        else:
+            support_message = ("If you need help with this issue, please contact our support team at "
+                               "{0}.").format(self._SUPPORT_EMAIL)
         Exception.__init__(
             self,
-            "%s\n\n"
-            "If you need help with this issue, please contact our support team at "
-            "support@shotgunsoftware.com." % message
+            "%s\n\n%s" % (message, support_message)
         )
 
 
@@ -108,9 +118,9 @@ class UnexpectedConfigFound(ShotgunDesktopError):
         """Constructor"""
         ShotgunDesktopError.__init__(
             self,
-            "A pipeline configuration was found at \"%s\" but no matching pipeline configuration was found in Shotgun.\n\n"
-            "This can happen if you are not assigned to the \"Template Project\". Please contact your Shotgun "
-            "Administrator to see if that is the case." % default_site_config
+            "A pipeline configuration was found at \"%s\" but no matching pipeline configuration was found in"
+            "Shotgun.\n\nThis can happen if you are not assigned to the \"Template Project\". Please contact "
+            "your Shotgun Administrator to see if that is the case." % default_site_config
         )
 
 
@@ -141,6 +151,7 @@ class BundledDescriptorEnvVarError(ShotgunDesktopError):
             "Error parsing SGTK_DESKTOP_BUNDLED_DESCRIPTOR: %s" % reason
         )
 
+
 class EnvironmentVariableFileLookupError(ShotgunDesktopError):
     """
     Raised when an environment variable specifying a location points to configuration
@@ -161,3 +172,14 @@ class EnvironmentVariableFileLookupError(ShotgunDesktopError):
         )
 
 
+class MissingAppStoreCredentialsError(ShotgunDesktopError):
+    """
+    Raised when there is not app store key set in Shotgun.
+    """
+
+    def __init__(self):
+        super(MissingAppStoreCredentialsError, self).__init__(
+            "Toolkit App Store credentials could not be retrieved from Shotgun.",
+            # Require that the client contacts support
+            support_required=True
+        )

--- a/python/shotgun_desktop/initialization/initialize.py
+++ b/python/shotgun_desktop/initialization/initialize.py
@@ -44,7 +44,9 @@ def initialize(splash, connection, app_store_http_proxy):
     # grab the login to the app store
     app_store_script = shotgun.get_app_store_credentials(connection, actual_app_store_proxy)
     if app_store_script is None:
-        raise RuntimeError("did not get app store script")
+        raise RuntimeError(
+            "App Store credentials couldn't be retrieved from Shotgun. Please contact support."
+        )
 
     # translate platform for locations and executables
     if sys.platform == "darwin":

--- a/python/shotgun_desktop/initialization/initialize.py
+++ b/python/shotgun_desktop/initialization/initialize.py
@@ -16,6 +16,7 @@ import tempfile
 from . import install
 from . import shotgun
 from .. import paths
+from ..errors import MissingAppStoreCredentialsError
 
 
 def initialize(splash, connection, app_store_http_proxy):
@@ -44,9 +45,7 @@ def initialize(splash, connection, app_store_http_proxy):
     # grab the login to the app store
     app_store_script = shotgun.get_app_store_credentials(connection, actual_app_store_proxy)
     if app_store_script is None:
-        raise RuntimeError(
-            "App Store credentials couldn't be retrieved from Shotgun. Please contact support."
-        )
+        raise MissingAppStoreCredentialsError()
 
     # translate platform for locations and executables
     if sys.platform == "darwin":

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -813,8 +813,10 @@ def __handle_unexpected_exception(splash, shotgun_authenticator, error_message, 
         "Shotgun Desktop Error",
         "Something went wrong in the Shotgun Desktop! If you drop us an email at "
         "support@shotgunsoftware.com, we'll help you diagnose the issue.\n"
-        "For more information, see the log file at %s.\n"
-        "Error: %s" % (app_bootstrap.get_logfile_location(), str(error_message)),
+        "Error: %s\n"
+        "For more information, see the log file at %s." % (
+            str(error_message), app_bootstrap.get_logfile_location()
+        ),
         detailed_text="".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
     )
     # If we are logged in, we should log out so the user is not stuck in a loop of always


### PR DESCRIPTION
Cleaner error message in Desktop.
Was
![screen shot 2017-02-01 at 09 13 14](https://cloud.githubusercontent.com/assets/8126447/22510115/b2d212c0-e85e-11e6-9575-60e30478b617.png)
now is
![screen shot 2017-02-01 at 09 12 37](https://cloud.githubusercontent.com/assets/8126447/22510082/975a1e8e-e85e-11e6-82b7-e9aaf867781e.png)
Also, for unexpected errors, I've moved the message that says where the log files are located at the bottom of the error dialog, otherwise there's a lot of text to go through before getting to the actual error.
Here's what it looks like now (and you can look at the first pic to get an idea of what it looked like before)
![screen shot 2017-02-01 at 09 17 33](https://cloud.githubusercontent.com/assets/8126447/22510255/4dfbf1bc-e85f-11e6-8f1c-5ec3c2a2e9cf.png)

