### PR TITLE
For #39874, missing app store key handling in zero config

### DIFF
--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -121,8 +121,6 @@ class BundledDescriptorEnvVarError(ShotgunDesktopError):
         )
 
 
-
-
 class EnvironmentVariableFileLookupError(ShotgunDesktopError):
     """
     Raised when an environment variable specifying a location points to configuration
@@ -141,5 +139,3 @@ class EnvironmentVariableFileLookupError(ShotgunDesktopError):
                 path
             )
         )
-
-

--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -30,13 +30,22 @@ class ShotgunDesktopError(Exception):
     """
     Common base class for Shotgun Desktop errors.
     """
-    def __init__(self, message):
-        """Constructor"""
+    _SUPPORT_EMAIL = "support@shotgunsoftware.com"
+
+    def __init__(self, message, support_required=False):
+        """
+        :param message: Error message to display.
+        :param optional_support: Indicates if the epilog should mention that contacting support is optional
+             or required to resolve this issue.
+        """
+
+        if support_required:
+            support_message = "Please contact {0} to resolve this issue.".format(self._SUPPORT_EMAIL)
+        else:
+            support_message = ("If you need help with this issue, please contact {0}.").format(self._SUPPORT_EMAIL)
         Exception.__init__(
             self,
-            "%s\n\n"
-            "If you need help with this issue, please contact our support team at "
-            "support@shotgunsoftware.com." % message
+            "%s\n\n%s" % (message, support_message)
         )
 
 
@@ -100,18 +109,6 @@ class ToolkitDisabledError(ShotgunDesktopError):
         )
 
 
-class MissingConfigError(ShotgunDesktopError):
-    """
-    This exception notifies the catcher that a configuration was missing on disk.
-    """
-    def __init__(self, default_site_config):
-        """Constructor"""
-        ShotgunDesktopError.__init__(
-            self,
-            "The pipeline configuration at \"%s\" was not found."
-        )
-
-
 class BundledDescriptorEnvVarError(ShotgunDesktopError):
     """
     This exception notifies the catcher that the bundled descriptor in
@@ -122,6 +119,7 @@ class BundledDescriptorEnvVarError(ShotgunDesktopError):
             self,
             "Error parsing SGTK_DESKTOP_BUNDLED_DESCRIPTOR: %s" % reason
         )
+
 
 
 class EnvironmentVariableFileLookupError(ShotgunDesktopError):
@@ -144,3 +142,14 @@ class EnvironmentVariableFileLookupError(ShotgunDesktopError):
         )
 
 
+class MissingAppStoreCredentialsError(ShotgunDesktopError):
+    """
+    Raised when there is not app store key set in Shotgun.
+    """
+
+    def __init__(self):
+        super(MissingAppStoreCredentialsError, self).__init__(
+            "Toolkit App Store credentials could not be retrieved from Shotgun.",
+            # Require that the client contacts support
+            support_required=True
+        )

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -570,8 +570,10 @@ def __handle_unexpected_exception(splash, shotgun_authenticator, error_message, 
         "Shotgun Desktop Error",
         "Something went wrong in the Shotgun Desktop! If you drop us an email at "
         "support@shotgunsoftware.com, we'll help you diagnose the issue.\n"
-        "For more information, see the log file at %s.\n"
-        "Error: %s" % (app_bootstrap.get_logfile_location(), str(error_message)),
+        "Error: %s\n"
+        "For more information, see the log file at %s." % (
+            str(error_message), app_bootstrap.get_logfile_location()
+        ),
         detailed_text="".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
     )
     # If we are logged in, we should log out so the user is not stuck in a loop of always

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -871,6 +871,7 @@ def main(**kwargs):
     # We have gui, websocket library and the authentication module, now do the rest.
     server = None
     from sgtk import authentication
+    from sgtk.descriptor import InvalidAppStoreCredentialsError
     try:
         # Reading user settings from disk.
         settings = Settings()
@@ -928,6 +929,9 @@ def main(**kwargs):
         splash.hide()
         shotgun_authenticator.clear_default_user()
         return 0
+    except InvalidAppStoreCredentialsError, e:
+        __handle_exception(splash, shotgun_authenticator, str(e))
+        return -1
     except ShotgunDesktopError, e:
         __handle_exception(splash, shotgun_authenticator, str(e))
         return -1


### PR DESCRIPTION
Handles the new app store exceptions from core during startup.
UX is the same as in the master branch.

![screen shot 2017-02-01 at 09 12 37](https://cloud.githubusercontent.com/assets/8126447/22510082/975a1e8e-e85e-11e6-82b7-e9aaf867781e.png)

Note that the core hasn't been merged into this PR to keep it brief. Once the core is approved it will be merged into this branch and then into zero_config
