### PR TITLE
Add support on desktop systems without internet access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.orig
 
 .DS_STORE
+
+# IDE files
+.idea/

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -48,9 +48,6 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
     if not _supports_get_from_location_and_paths(sgtk):
         return False
 
-    if 'SGTK_DESKTOP_DISABLE_UPDATE' in os.environ:
-        return False
-
     current_desc = sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
         app_bootstrap.get_shotgun_desktop_cache_location(),

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -48,6 +48,9 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
     if not _supports_get_from_location_and_paths(sgtk):
         return False
 
+    if 'SGTK_DESKTOP_DISABLE_UPDATE' in os.environ:
+        return False
+
     current_desc = sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
         app_bootstrap.get_shotgun_desktop_cache_location(),
@@ -78,7 +81,7 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
         latest_descriptor = current_desc.find_latest_version()
     # Connection errors can occur for a variety of reasons. For example, there is no internet access
     # or there is a proxy server blocking access to the Toolkit app store
-    except (httplib2.HttpLib2Error, httplib2.socks.HTTPError, httplib.HTTPException), e:
+    except (httplib2.HttpLib2Error, httplib2.socks.HTTPError, httplib.HTTPException, sgtk.descriptor.errors.TankAppStoreConnectionError), e:
         logger.warning("Could not access the TK App Store (tank.shotgunstudio.com): (%s)." % e)
         return False
     # In cases where there is a firewall/proxy blocking access to the app store, sometimes the 


### PR DESCRIPTION
On systems without internet access to tank.shotgunstudio.com, Shotgun Desktop will fatally error out checking for updates on startup.

The update code is setup to catch and ignore the types of exceptions that would be encountered when a computer doesn't have internet access; however, the connection code in `tank.descriptor.io_descriptor.appstore` also catches those types of errors and re-casts them as `TankAppStoreConnectionError`'s.

Considering Shotgun Desktop was already trying to prevent fatal errors if the app store couldn't be reached, it seems appropriate to also catch and ignore the re-cast error raised by tank.

An additional feature was added to support skipping the auto-update on startup altogether.  This speeds up startup on systems that will never be connected to the internet, since it prevents having to wait for the request to the app store to timeout.



