### PR TITLE
Fix incompatible QT plugins on Centos 7 - KDE

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -280,6 +280,14 @@ def __init_app():
     :returns: The tupple (QApplication instance, shogun_desktop.splash.Slash instance).
     """
     logger.debug("Creating QApp and splash screen")
+    # Before starting QApplication, disable system default QT plugins.
+    # The installed QT version on the system might be different then the one we ship with.
+    # Incompatible plugins prevent the application from starting.
+    # This problem was reproducible on Centos 7 with KDE.
+    # We need to remove this env var to make sure every other process starting a
+    # QApplication in this same environment will not have problems.
+    if os.environ.get("QT_PLUGIN_PATH"):
+        del os.environ["QT_PLUGIN_PATH"]
     # start up our QApp now
     return QtGui.QApplication(sys.argv), shotgun_desktop.splash.Splash()
 


### PR DESCRIPTION
The problem :
The currently certified Flame station is Centos 7 with KDE and QT version 1.8.5.
Clients at the moment cannot start shotgun desktop application without previously calling "
unsetenv QT_PLUGIN_PATH" because the QApplication will try to load KDE plugins incompatible with QT 1.8.7 shipped with shotgun.

The solution:
Remove QT plugins before starting QApplication

Impacts:
I do not have access to other platform and I would like to have your feedback about the implication of that change. My thoughts was that it is risky to allow external plugins if we ship with our own QT version.