### PR TITLE
For #41850, banner updates

### DIFF
--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -84,6 +84,19 @@ def get_location(app_bootstrap):
         return yaml.load(location_file) or dev_descriptor
 
 
+def get_startup_descriptor(sgtk, sg, app_bootstrap):
+    """
+    Creates a startup descriptor based for the currently running desktop startup code.
+
+    :returns: :class:`sgtk.descriptor.FrameworkDescriptor` instance.
+    """
+    return sgtk.descriptor.create_descriptor(
+        sg,
+        sgtk.descriptor.Descriptor.FRAMEWORK,
+        get_location(app_bootstrap)
+    )
+
+
 def write_location(descriptor):
     """
     Writes the descriptor dictionary to disk in the BUNDLE_ROOT/resources/location.yml file.

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -53,7 +53,7 @@ import shotgun_desktop.paths
 from shotgun_desktop.turn_on_toolkit import TurnOnToolkit
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
 from shotgun_desktop.upgrade_startup import upgrade_startup
-from shotgun_desktop.location import get_location
+from shotgun_desktop.location import get_startup_descriptor
 from shotgun_desktop.settings import Settings
 from shotgun_desktop.systray_icon import ShotgunSystemTrayIcon
 from distutils.version import LooseVersion
@@ -521,6 +521,7 @@ def __post_bootstrap_engine(splash, app_bootstrap, engine):
 
     :returns: Application exit code.
     """
+    import sgtk
 
     # reset PYTHONPATH and PYTHONHOME if they were overridden by the application
     if "SGTK_DESKTOP_ORIGINAL_PYTHONPATH" in os.environ:
@@ -530,12 +531,15 @@ def __post_bootstrap_engine(splash, app_bootstrap, engine):
 
     # and run the engine
     logger.debug("Running tk-desktop")
-    startup_version = get_location(app_bootstrap).get("version") or "Undefined"
+    startup_desc = get_startup_descriptor(sgtk, engine.shotgun, app_bootstrap)
+
+    startup_version = startup_desc.version
 
     return engine.run(
         splash,
         version=app_bootstrap.get_version(),
-        startup_version=startup_version
+        startup_version=startup_version,
+        startup_descriptor=startup_desc
     )
 
 

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from shotgun_desktop.location import get_location, write_location
+from shotgun_desktop.location import write_location, get_startup_descriptor
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
 from sgtk.descriptor import CheckVersionConstraintsError
 
@@ -47,11 +47,7 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
 
     sg = sgtk.get_authenticated_user().create_sg_connection()
 
-    current_desc = sgtk.descriptor.create_descriptor(
-        sg,
-        sgtk.descriptor.Descriptor.FRAMEWORK,
-        get_location(app_bootstrap)
-    )
+    current_desc = get_startup_descriptor(sgtk, sg, app_bootstrap)
 
     logger.debug("Testing for remote access: %s", current_desc)
 


### PR DESCRIPTION
The startup code now pushes a descriptor of the current desktop startup code to the engine.