### PR TITLE
For #42840, bootstrap into 0.16

### DIFF
--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-copyright = """# Copyright (c) 2015 Shotgun Software Inc.
+copyright = """# Copyright (c) 2017 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -21,7 +21,6 @@ copyright = """# Copyright (c) 2015 Shotgun Software Inc.
 """
 
 import os
-from .errors import BundledDescriptorEnvVarError
 
 
 def _get_location_yaml_location(root):
@@ -64,11 +63,6 @@ def get_location(app_bootstrap):
 
     # Local import since sgtk is lazily loaded.
     from tank_vendor import yaml
-    if app_bootstrap.runs_bundled_startup() and "SGTK_DESKTOP_BUNDLED_DESCRIPTOR" in os.environ:
-        try:
-            return yaml.load(os.environ["SGTK_DESKTOP_BUNDLED_DESCRIPTOR"])
-        except yaml.YAMLError, e:
-            raise BundledDescriptorEnvVarError(e)
 
     location = _get_location_yaml_location(app_bootstrap.get_startup_path())
     # If the file is missing, we're in dev mode.
@@ -90,9 +84,13 @@ def get_startup_descriptor(sgtk, sg, app_bootstrap):
 
     :returns: :class:`sgtk.descriptor.FrameworkDescriptor` instance.
     """
-    return sgtk.descriptor.create_descriptor(
-        sg,
-        sgtk.descriptor.Descriptor.FRAMEWORK,
+    # Use the old API to create the descriptor, as we might be using a 0.16-based core.
+    return sgtk.deploy.descriptor.get_from_location_and_paths(
+        sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
+        app_bootstrap.get_shotgun_desktop_cache_location(),
+        os.path.join(
+            app_bootstrap.get_shotgun_desktop_cache_location(), "install"
+        ),
         get_location(app_bootstrap)
     )
 

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -70,7 +70,8 @@ def __restore_global_debug_flag():
     """
     global global_debug_flag_at_startup
     import sgtk
-    sgtk.LogManager().global_debug = global_debug_flag_at_startup
+    if hasattr(sgtk, "LogManager"):
+        sgtk.LogManager().global_debug = global_debug_flag_at_startup
 
 
 def __backup_global_debug_flag():
@@ -553,7 +554,8 @@ def __post_bootstrap_engine(splash, app_bootstrap, engine, settings):
     logger.debug("Running tk-desktop")
     startup_desc = get_startup_descriptor(sgtk, engine.shotgun, app_bootstrap)
 
-    startup_version = startup_desc.version
+    # Uses the old API as we may have bootstrap into an old core.
+    startup_version = startup_desc.get_version()
 
     # If the site config is running an older version of the desktop engine, it
     # doesn't include browser integration, so we'll launch it ourselves.

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -70,6 +70,7 @@ def __restore_global_debug_flag():
     """
     global global_debug_flag_at_startup
     import sgtk
+    # If there is no LogManager for the new core, there's no need to restore any flag.
     if hasattr(sgtk, "LogManager"):
         sgtk.LogManager().global_debug = global_debug_flag_at_startup
 


### PR DESCRIPTION
Fixes some backwards compatibility issues with core 0.16.