### PR TITLE
SG:18139: Python and SG version in splash screen

### DIFF
--- a/python/shotgun_desktop/splash.py
+++ b/python/shotgun_desktop/splash.py
@@ -38,6 +38,9 @@ class Splash(QtGui.QDialog):
         self.ui.message.setText(text)
         QtGui.QApplication.instance().processEvents()
 
+    def set_version(self, version):
+        self.ui.version.setText(version)
+
     def show(self):
         """
         Shows the dialog of top of all other dialogs.

--- a/python/shotgun_desktop/splash.py
+++ b/python/shotgun_desktop/splash.py
@@ -39,6 +39,11 @@ class Splash(QtGui.QDialog):
         QtGui.QApplication.instance().processEvents()
 
     def set_version(self, version):
+        """
+        Set the version of the Shotgun Desktop on the widget.
+
+        :param str version: Version of the app.
+        """
         self.ui.version.setText(version)
 
     def show(self):

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -22,13 +22,34 @@ import logging
 
 
 def _enumerate_per_line(items):
+    """
+    Enumerate all items from an array, one line at a time.
+
+    For example,
+        - one
+        - two
+        - three
+
+    :returns: The formatted output.
+    """
     return "\n".join("- {}".format(item) for item in items)
 
 
 def _env_not_set_or_split(var_name):
+    """
+    Format a PATH-like environment variable for output.
+
+    :param str var_name: Name of the env var.
+    :returns: "Not Set" if variable is not set, a bullet list otherwise.
+    """
     if var_name not in os.environ:
         return "Not Set"
     else:
+        # Add a \n before the first item so each item in the output start from the
+        # beginning of the time. Otherwise you'd get.
+        # varname: - one
+        # - two
+        # - three.
         return "\n" + _enumerate_per_line(os.environ[var_name].split(os.path.pathsep))
 
 

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -15,7 +15,6 @@ import sys
 import time
 import subprocess
 import traceback
-import pprint
 
 # initialize logging
 import logging
@@ -46,7 +45,7 @@ def _env_not_set_or_split(var_name):
         return "Not Set"
     else:
         # Add a \n before the first item so each item in the output start from the
-        # beginning of the time. Otherwise you'd get.
+        # beginning of the line. Otherwise you'd get
         # varname: - one
         # - two
         # - three.

--- a/python/shotgun_desktop/ui/resources_rc.py
+++ b/python/shotgun_desktop/ui/resources_rc.py
@@ -2,7 +2,7 @@
 
 # Resource object code
 #
-#      by: The Resource Compiler for PySide (Qt v4.8.7)
+#      by: The Resource Compiler for PySide (Qt v4.8.6)
 #
 # WARNING! All changes made in this file will be lost!
 

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -45,11 +45,13 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setGeometry(QtCore.QRect(182, 146, 316, 31))
+        self.message.setText("")
         self.message.setAlignment(QtCore.Qt.AlignLeading|QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
         self.message.setObjectName("message")
         self.version = QtGui.QLabel(Splash)
         self.version.setGeometry(QtCore.QRect(390, 40, 101, 20))
         self.version.setStyleSheet("color: rgb(104, 123, 135);")
+        self.version.setText("")
         self.version.setAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignTrailing|QtCore.Qt.AlignVCenter)
         self.version.setObjectName("version")
 
@@ -58,7 +60,5 @@ class Ui_Splash(object):
 
     def retranslateUi(self, Splash):
         Splash.setWindowTitle(QtGui.QApplication.translate("Splash", "Dialog", None, QtGui.QApplication.UnicodeUTF8))
-        self.message.setText(QtGui.QApplication.translate("Splash", "Downloading tk-framework-desktopserver v1.4.5 (10 of 15)", None, QtGui.QApplication.UnicodeUTF8))
-        self.version.setText(QtGui.QApplication.translate("Splash", "v1.6.0 - Python 2", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -45,14 +45,20 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setGeometry(QtCore.QRect(182, 146, 316, 31))
-        self.message.setText("")
         self.message.setAlignment(QtCore.Qt.AlignLeading|QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
         self.message.setObjectName("message")
+        self.version = QtGui.QLabel(Splash)
+        self.version.setGeometry(QtCore.QRect(390, 40, 101, 20))
+        self.version.setStyleSheet("color: rgb(104, 123, 135);")
+        self.version.setAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignTrailing|QtCore.Qt.AlignVCenter)
+        self.version.setObjectName("version")
 
         self.retranslateUi(Splash)
         QtCore.QMetaObject.connectSlotsByName(Splash)
 
     def retranslateUi(self, Splash):
         Splash.setWindowTitle(QtGui.QApplication.translate("Splash", "Dialog", None, QtGui.QApplication.UnicodeUTF8))
+        self.message.setText(QtGui.QApplication.translate("Splash", "Downloading tk-framework-desktopserver v1.4.5 (10 of 15)", None, QtGui.QApplication.UnicodeUTF8))
+        self.version.setText(QtGui.QApplication.translate("Splash", "v1.6.0 - Python 2", None, QtGui.QApplication.UnicodeUTF8))
 
 from . import resources_rc

--- a/resources/build_resources.sh
+++ b/resources/build_resources.sh
@@ -11,9 +11,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # The path to where the PySide binaries are installed
-PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python"
-PYTHON_LIB="${PYTHON_BASE}/lib/python2.7"
-
 # The path to output all built .py files to:
 UI_PYTHON_PATH=../python/shotgun_desktop/ui
 
@@ -28,11 +25,11 @@ function build_qt {
 }
 
 function build_ui {
-    build_qt "${PYTHON_BASE}/bin/python ${PYTHON_BASE}/bin/pyside-uic --from-imports" "$1.ui" "$1"
+    build_qt "pyside-uic --from-imports" "$1.ui" "$1"
 }
 
 function build_res {
-    build_qt "${PYTHON_BASE}/bin/pyside-rcc -py3" "$1.qrc" "$1_rc"
+    build_qt "pyside-rcc -py3" "$1.qrc" "$1_rc"
 }
 
 # build UI's:

--- a/resources/build_resources.sh
+++ b/resources/build_resources.sh
@@ -10,7 +10,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-# The path to where the PySide binaries are installed
 # The path to output all built .py files to:
 UI_PYTHON_PATH=../python/shotgun_desktop/ui
 

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -91,10 +91,29 @@ QWidget
     </rect>
    </property>
    <property name="text">
-    <string/>
+    <string>Downloading tk-framework-desktopserver v1.4.5 (10 of 15)</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="version">
+   <property name="geometry">
+    <rect>
+     <x>390</x>
+     <y>40</y>
+     <width>101</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">color: rgb(104, 123, 135);</string>
+   </property>
+   <property name="text">
+    <string>v1.6.0 - Python 2</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
    </property>
   </widget>
  </widget>

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -91,7 +91,7 @@ QWidget
     </rect>
    </property>
    <property name="text">
-    <string>Downloading tk-framework-desktopserver v1.4.5 (10 of 15)</string>
+    <string/>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -110,7 +110,7 @@ QWidget
     <string notr="true">color: rgb(104, 123, 135);</string>
    </property>
    <property name="text">
-    <string>v1.6.0 - Python 2</string>
+    <string/>
    </property>
    <property name="alignment">
     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
We're now displaying the Python and Desktop version on the splash screen. The Python version is displayed only for builds who will support both Python 2 and 3.
![Screen Shot 2020-06-29 at 13 30 06](https://user-images.githubusercontent.com/8126447/86042358-09d11b80-ba15-11ea-847b-78a1b6c99de0.png)

As for the logging enhancements, it looks like this:
```
Python
======
Executable: /Applications/Shotgun.app/Contents/MacOS/Shotgun
Version: 2.7.17
sys.path:
- /Users/boismej/gitlocal/tk-framework-desktopstartup/python
- /Applications/Shotgun.app/Contents/Resources/Desktop/Python
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python27.zip
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-darwin
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-mac
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/plat-mac/lib-scriptpackages
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-tk
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-old
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/lib-dynload
- /Users/boismej/.local/lib/python2.7/site-packages
- /Users/boismej/gitlocal/mpas-ma
- /Applications/Shotgun.app/Contents/Resources/Python/lib/python2.7/site-packages
Environment variables
=====================
PATH: 
- /usr/local/opt/tcl-tk/bin
- /Users/boismej/.cargo/bin
- /Users/boismej/.rvm/gems/ruby-2.7.0/bin
- /Users/boismej/.rvm/gems/ruby-2.7.0@global/bin
- /Users/boismej/.rvm/rubies/ruby-2.7.0/bin
- /usr/local/Cellar/pyenv-virtualenv/1.1.3/shims
- /Users/boismej/.pyenv/shims
- /usr/local/bin
- /usr/bin
- /bin
- /usr/sbin
- /sbin
- /Applications/VMware Fusion.app/Contents/Public
- /Library/Frameworks/Mono.framework/Versions/Current/Commands
- /Users/boismej/.rvm/bin
- /Users/boismej/.rvm/bin
PYTHONHOME: Not Set
PYTHONPATH: Not Set
SGTK_DESKTOP_ORIGINAL_PYTHONHOME: Not Set 
SGTK_DESKTOP_ORIGINAL_PYTHONPATH: 
- /Users/boismej/scripts
- /Applications/PyCharm.app/Contents/helpers/pydev
```
