### PR TITLE
SG-20242: old site config warning

### DIFF
--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -135,19 +135,6 @@ class UpgradeEngine200Error(ShotgunDesktopError):
         )
 
 
-class ToolkitDisabledError(ShotgunDesktopError):
-    """
-    This exception notifies the catcher that Toolkit has not been enabled by the user on the site.
-    """
-
-    def __init__(self):
-        """Constructor"""
-        ShotgunDesktopError.__init__(
-            self,
-            "Toolkit has not been activated on your site. Please activate Toolkit before relaunching Shotgun Desktop.",
-        )
-
-
 class MissingPython3SupportError(ShotgunDesktopError):
     def __init__(self):
         """
@@ -155,6 +142,20 @@ class MissingPython3SupportError(ShotgunDesktopError):
         super(MissingPython3SupportError, self).__init__(
             "The tk-desktop engine in your site configuration may not support Python 3.\n"
             "\n"
-            "You need to upgrade the tk-desktop engine to v2.5.3+ in your site configuration or "
+            "You need to upgrade the tk-desktop engine to v2.5.9+ in your site configuration or "
             "launch the Shotgun Desktop in Python 2 mode."
+        )
+
+
+class EngineIncompatibleWithDesktop160(ShotgunDesktopError):
+    def __init__(self, engine, app_version):
+        super(EngineIncompatibleWithDesktop160, self).__init__(
+            "tk-desktop {0} is not compatible with Shotgun Desktop {1}.\n"
+            "\n"
+            "Please upgrade your site configuration's tk-desktop to v2.5.9+ or "
+            "download Shotgun Desktop 1.5.9 or earlier <a href='{2}'>here</a>".format(
+                engine.version,
+                app_version,
+                "https://support.shotgunsoftware.com/hc/en-us/articles/219039888-Shotgun-Desktop-Release-Notes",
+            )
         )

--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -135,26 +135,13 @@ class UpgradeEngine200Error(ShotgunDesktopError):
         )
 
 
-class MissingPython3SupportError(ShotgunDesktopError):
-    def __init__(self):
-        """
-        """
-        super(MissingPython3SupportError, self).__init__(
-            "The tk-desktop engine in your site configuration may not support Python 3.\n"
-            "\n"
-            "You need to upgrade the tk-desktop engine to v2.5.9+ in your site configuration or "
-            "launch the Shotgun Desktop in Python 2 mode."
-        )
-
-
-class EngineIncompatibleWithDesktop160(ShotgunDesktopError):
-    def __init__(self, engine, app_version):
-        super(EngineIncompatibleWithDesktop160, self).__init__(
-            "tk-desktop {0} is not compatible with Shotgun Desktop {1}.\n"
+class EngineNotCompatibleWithDesktop16(ShotgunDesktopError):
+    def __init__(self, app_version):
+        super(EngineNotCompatibleWithDesktop16, self).__init__(
+            "Your version of tk-desktop is not compatible with Shotgun Desktop {0}.\n"
             "\n"
             "Please upgrade your site configuration's tk-desktop to v2.5.9+ or "
-            "download Shotgun Desktop 1.5.9 or earlier <a href='{2}'>here</a>".format(
-                engine.version,
+            "download Shotgun Desktop 1.5.9 or earlier <a style='color: rgb(35,165,225)' href='{1}'>here</a>".format(
                 app_version,
                 "https://support.shotgunsoftware.com/hc/en-us/articles/219039888-Shotgun-Desktop-Release-Notes",
             )

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -122,11 +122,10 @@ from shotgun_desktop.errors import (
     ShotgunDesktopError,
     RequestRestartException,
     UpgradeEngine200Error,
-    EngineIncompatibleWithDesktop160,
+    EngineNotCompatibleWithDesktop16,
     UpgradeCoreError,
     UpgradeCorePython3Error,
     InvalidPipelineConfiguration,
-    MissingPython3SupportError,
 )
 
 from tank.util.version import (
@@ -407,7 +406,7 @@ def __launch_app(app, splash, user, app_bootstrap, settings):
             "python/tk_desktop/".replace("/", os.path.sep)
             in deepest.tb_frame.f_code.co_filename
         ):
-            raise MissingPython3SupportError()
+            raise EngineNotCompatibleWithDesktop16(app_bootstrap.get_version())
         raise
     except Exception as e:
         # We may end up here when running with an older version of core pre 0.19.
@@ -587,7 +586,7 @@ def __post_bootstrap_engine(splash, app_bootstrap, engine, settings):
             "PySide2.QtCore.qRegisterResourceData' called with wrong argument types"
             in str(e)
         ):
-            raise MissingPython3SupportError()
+            raise EngineNotCompatibleWithDesktop16(app_bootstrap.get_version())
         raise
 
 
@@ -615,7 +614,7 @@ def __ensure_engine_compatible_with_qt_version(engine, app_version):
 
     # Versions of desktop older than v2.5.0 have issues with desktop 1.6.1+, so raise an error.
     if is_version_newer_or_equal(app_version, "v1.6.1"):
-        raise EngineIncompatibleWithDesktop160(engine, app_version)
+        raise EngineNotCompatibleWithDesktop16(app_version)
 
 
 def _run_engine(engine, splash, startup_version, app_bootstrap, startup_desc, settings):


### PR DESCRIPTION
Makes sure the tk-desktop engine is compatible with the PySide version we distribute with Desktop.

When using tk-desktop versions before v2.5.0, PySide2 builds of desktop can't launch DCCs because a QAction's signal emit an unexpected boolean that crashes older tk-desktop versions.

This is what will be shown to the user:

![image](https://user-images.githubusercontent.com/8126447/99551790-441e6380-298a-11eb-9752-c03df407aeb8.png)

UPDATE:

I updated the dialog a bit. The hyperlink was hard to read so I made the link the same color as our button. After feedback from QA, I've refactored our error messages for Python/PySide incompatibilities and am using the same message everywhere now.

Since the same error message can now be used, even when we can't start the engine, I had to remove the version of the engine from the error message.

![image](https://user-images.githubusercontent.com/8126447/99564945-112f9c00-2999-11eb-8e90-d0437a103fe6.png)
