### PR TITLE
SG-23377: Fixes Autodesk Identity login on Linux

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -19,6 +19,15 @@ import traceback
 # initialize logging
 import logging
 
+# On Shotgun Desktop 1.7.0 on Linux, sys.executable is not properly set.
+# The Python 3 version reports /opt/Shotgun/Python3/bin/python3
+# The Python 2 version reports an empty string.
+# Instead, we'll use sys.prefix which is properly set and backtrack to the executable.
+# When the executable is fixed we should come back here and put a check for the version
+# number so we stop updating sys.prefix
+if sys.platform.startswith("linux"):
+    sys.executable = os.path.normpath(os.path.join(sys.prefix, "..", "Shotgun"))
+
 
 def _enumerate_per_line(items):
     """

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -44,6 +44,7 @@ if executable_name.lower() not in ["shotgun", "shotgrid"]:
     # Set the executable name and make sure to put back in the extension for Windows.
     sys.executable = os.path.normpath(os.path.join(bin_dir, "Shotgun%s" % ext))
 
+
 def _enumerate_per_line(items):
     """
     Enumerate all items from an array, one line at a time.


### PR DESCRIPTION
Workaround for `sys.executable` not being set properly in the Shotgun Desktop 1.7.0 and below.

This workaround is required because the Toolkit core tests whether it is running inside Shotgun Desktop by looking at `sys.executable` in two places. We'll fix the linux binaries at some point, but in the meantime we'll monkey patch `sys.executable` so it is properly set on Linux and we don't need to make tk-core more complicated.

We'll need to test this with 1.5.3, 1.6.1 and 1.7.0. The fix only affects linux, so we can do a quick sanity check on Windows and Mac, but nothing too fancy.