### PR TITLE
For SG-18096: first phase of web login support in Desktop

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -839,7 +839,7 @@ def main(**kwargs):
     from sgtk.descriptor import InvalidAppStoreCredentialsError
     from sgtk.authentication import (
         set_shotgun_authenticator_support_web_login,
-        ShotgunSamlUser
+        ShotgunSamlUser,
     )
 
     try:
@@ -850,8 +850,10 @@ def main(**kwargs):
         # If there is an error during auto login, for example proxy settings changed and you
         # can't connect anymore, we need to be able to log the user out.
         shotgun_authenticator = sgtk.authentication.ShotgunAuthenticator()
-        if os.environ.get('SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE'):
-            logger.info("Indicating to the Desktop that web loging is supported and to be used.")
+        if os.environ.get("SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE"):
+            logger.info(
+                "Indicating to the Desktop that web loging is supported and to be used."
+            )
             set_shotgun_authenticator_support_web_login(True)
         __optional_state_cleanup(splash, shotgun_authenticator, app_bootstrap)
 

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -852,7 +852,7 @@ def main(**kwargs):
         shotgun_authenticator = sgtk.authentication.ShotgunAuthenticator()
         if os.environ.get("SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE"):
             logger.info(
-                "Indicating to the Desktop that web loging is supported and to be used."
+                "Indicating to the Desktop that web login is supported and to be used."
             )
             set_shotgun_authenticator_support_web_login(True)
         __optional_state_cleanup(splash, shotgun_authenticator, app_bootstrap)

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -837,7 +837,10 @@ def main(**kwargs):
 
     from sgtk import authentication
     from sgtk.descriptor import InvalidAppStoreCredentialsError
-    from sgtk.authentication import ShotgunSamlUser
+    from sgtk.authentication import (
+        set_shotgun_authenticator_support_web_login,
+        ShotgunSamlUser
+    )
 
     try:
         # Reading user settings from disk.
@@ -847,7 +850,9 @@ def main(**kwargs):
         # If there is an error during auto login, for example proxy settings changed and you
         # can't connect anymore, we need to be able to log the user out.
         shotgun_authenticator = sgtk.authentication.ShotgunAuthenticator()
-
+        if os.environ.get('SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE'):
+            logger.info("Indicating to the Desktop that web loging is supported and to be used.")
+            set_shotgun_authenticator_support_web_login(True)
         __optional_state_cleanup(splash, shotgun_authenticator, app_bootstrap)
 
         user = __do_login(splash, shotgun_authenticator)


### PR DESCRIPTION
The SG Desktop has supported Web login for years, in order to support SSO.

But this mode was not used for regular login/password authentication, in favour of the simpler Qt-based dialog.

Now with the arrival of Autodesk Identity as the de-facto authentication mode, the mechanics used for SSO login has been adapted to also work with Autodesk Identity.

As clients/sites are set to migrate from their old authentication mode to Identity, ShotGrid supports a dual-mode : where both the old authentication path (login/password or SSO) and Autodesk Identity are supported. This to allow users to validate that the new path is working fine, allowing them to use the old method should there be an issue.

Unfortunately for sites using the default login/password authentication, the SG Desktop will always use the old Qt-based dialog for authentication.

The intent is to transition to a state where the Desktop will always use the Web login mode (which is what is used by Identity). This will allow SG Desktop to also test the Autodesk Identity authentication during the dual-mode phase.

This will be done in 2 phases:

1. (THIS PR) Web login is off by default. The use of the environment variable `SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE` tells the desktop to use the Web login for all modes. This is to allow early adopters a way to test the dual mode authentication, and avoid disrupting too many user with the UX change.
2. (AN UPCOMING PR) Web login is on by default. The use of the environment variable `SGTK_DESKTOP_SUPPORT_WEB_LOGIN_FALSE` tells the desktop to always use the old Qt-based dialog when possible (for the login/password or for Autodesk Identity with Personal Access Token)

Screenshot of Default GUI (targeting a site in dual mode):
![Screen Shot 2021-08-10 at 23 44 10](https://user-images.githubusercontent.com/8060460/128966361-98c6861c-e518-4549-a420-49ee9775b66b.png)

Screenshot of the GUI with `SGTK_DESKTOP_SUPPORT_WEB_LOGIN_TRUE=1` (targeting a site in dual mode):
![Screen Shot 2021-08-10 at 23 44 41](https://user-images.githubusercontent.com/8060460/128966439-4dfde830-e9a9-466f-a3ef-b67a373b0a25.png)
![Screen Shot 2021-08-10 at 23 44 46](https://user-images.githubusercontent.com/8060460/128966459-221882f5-c728-491a-bb1d-3a606f4b35cb.png)
