### PR TITLE
SG-26411_SG Desktop Splash Screen doesn't Leave Enough Room for Progress Updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       exclude: "scripts\/tank_cmd.bat|setup\/root_binaries\/tank.bat"
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/python/shotgun_desktop/errors.py
+++ b/python/shotgun_desktop/errors.py
@@ -41,8 +41,10 @@ class ShotgunDesktopError(Exception):
         """
 
         if support_required:
-            support_message = "Please <a href={}>contact support</a> to resolve this issue.".format(
-                sgtk.support_url
+            support_message = (
+                "Please <a href={}>contact support</a> to resolve this issue.".format(
+                    sgtk.support_url
+                )
             )
         else:
             support_message = (
@@ -91,7 +93,8 @@ class UpgradeCoreError(ShotgunDesktopError):
             % (
                 reason,
                 os.path.join(
-                    toolkit_path, "tank.bat" if sgtk.util.is_windows() else "tank",
+                    toolkit_path,
+                    "tank.bat" if sgtk.util.is_windows() else "tank",
                 ),
             ),
         )

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -135,7 +135,7 @@ def get_pipeline_configuration_info(connection):
 
 
 def __get_site_from_connection(connection):
-    """ return the site from the information in the connection """
+    """return the site from the information in the connection"""
     # grab just the non-port part of the netloc of the url
     # eg site.shotgunstudio.com
     site = parse.urlparse(connection.base_url)[1].split(":")[0]

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -132,7 +132,14 @@ def add_to_python_path(bundled_path, env_var_override, module_name):
 
 
 # Add Toolkit to the path.
-add_to_python_path(os.path.join("..", "tk-core",), "SGTK_CORE_LOCATION", "tk-core")
+add_to_python_path(
+    os.path.join(
+        "..",
+        "tk-core",
+    ),
+    "SGTK_CORE_LOCATION",
+    "tk-core",
+)
 
 # now proceed with non builtin imports
 from .qt import QtCore, QtGui
@@ -474,8 +481,10 @@ def __start_engine_in_toolkit_classic(app, splash, user, pc, pc_path):
     mgr = sgtk.bootstrap.ToolkitManager(user)
     # Tell the manager to resolve the config in Shotgun so it can resolve the location on disk.
     mgr.do_shotgun_config_lookup = True
-    mgr.progress_callback = lambda progress_value, message: __bootstrap_progress_callback(
-        splash, app, progress_value, message
+    mgr.progress_callback = (
+        lambda progress_value, message: __bootstrap_progress_callback(
+            splash, app, progress_value, message
+        )
     )
     mgr.pipeline_configuration = pc["id"]
 
@@ -549,8 +558,10 @@ def __start_engine_in_zero_config(app, app_bootstrap, splash, user):
         "SHOTGUN_DESKTOP_CONFIG_FALLBACK_DESCRIPTOR",
         "sgtk:descriptor:app_store?name=tk-config-basic",
     )
-    mgr.progress_callback = lambda progress_value, message: __bootstrap_progress_callback(
-        splash, app, progress_value, message
+    mgr.progress_callback = (
+        lambda progress_value, message: __bootstrap_progress_callback(
+            splash, app, progress_value, message
+        )
     )
     mgr.plugin_id = "basic.desktop"
 
@@ -703,7 +714,9 @@ def __handle_unexpected_exception(
         "we'll help you diagnose the issue.\n"
         "Error: {error}\n"
         "For more information, see the log file at {log}.".format(
-            link=sgtk.support_url, error=str(error_message), log=log_location,
+            link=sgtk.support_url,
+            error=str(error_message),
+            log=log_location,
         ),
         detailed_text="".join(
             traceback.format_exception(exc_type, exc_value, exc_traceback)

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -46,7 +46,7 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setEnabled(False)
-        self.message.setGeometry(QtCore.QRect(20, 310, 251, 31))
+        self.message.setGeometry(QtCore.QRect(20, 280, 281, 31))
         self.message.setStyleSheet("color: rgb(255, 255, 255);\n"
 "background-color: rgb(0, 0, 0)")
         self.message.setText("")

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -46,7 +46,7 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setEnabled(False)
-        self.message.setGeometry(QtCore.QRect(20, 280, 281, 31))
+        self.message.setGeometry(QtCore.QRect(20, 260, 291, 31))
         self.message.setStyleSheet("color: rgb(255, 255, 255);\n"
 "background-color: rgb(0, 0, 0)")
         self.message.setText("")

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -46,9 +46,9 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setEnabled(False)
-        self.message.setGeometry(QtCore.QRect(20, 260, 291, 31))
+        self.message.setGeometry(QtCore.QRect(20, 330, 291, 31))
         self.message.setStyleSheet("color: rgb(255, 255, 255);\n"
-"background-color: rgb(0, 0, 0)")
+"background-color: transparent")
         self.message.setText("")
         self.message.setAlignment(QtCore.Qt.AlignLeading|QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
         self.message.setObjectName("message")

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -46,7 +46,7 @@ class Ui_Splash(object):
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
         self.message.setEnabled(False)
-        self.message.setGeometry(QtCore.QRect(20, 330, 291, 31))
+        self.message.setGeometry(QtCore.QRect(20, 330, 561, 31))
         self.message.setStyleSheet("color: rgb(255, 255, 255);\n"
 "background-color: transparent")
         self.message.setText("")

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -31,6 +31,7 @@ class Ui_Splash(object):
 "    font-size: 12px;\n"
 "}")
         self.icon = QtGui.QLabel(Splash)
+        self.icon.setEnabled(True)
         self.icon.setGeometry(QtCore.QRect(5, 5, 590, 390))
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
@@ -44,7 +45,8 @@ class Ui_Splash(object):
         self.icon.setScaledContents(True)
         self.icon.setObjectName("icon")
         self.message = QtGui.QLabel(Splash)
-        self.message.setGeometry(QtCore.QRect(20, 330, 221, 31))
+        self.message.setEnabled(False)
+        self.message.setGeometry(QtCore.QRect(20, 310, 251, 31))
         self.message.setStyleSheet("color: rgb(255, 255, 255);\n"
 "background-color: rgb(0, 0, 0)")
         self.message.setText("")

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -45,6 +45,9 @@ QWidget
 }</string>
   </property>
   <widget class="QLabel" name="icon">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="geometry">
     <rect>
      <x>5</x>
@@ -82,11 +85,14 @@ QWidget
    </property>
   </widget>
   <widget class="QLabel" name="message">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>330</y>
-     <width>221</width>
+     <y>310</y>
+     <width>251</width>
      <height>31</height>
     </rect>
    </property>

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -91,8 +91,8 @@ QWidget
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>310</y>
-     <width>251</width>
+     <y>280</y>
+     <width>281</width>
      <height>31</height>
     </rect>
    </property>

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -91,14 +91,14 @@ QWidget
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>260</y>
+     <y>330</y>
      <width>291</width>
      <height>31</height>
     </rect>
    </property>
    <property name="styleSheet">
     <string notr="true">color: rgb(255, 255, 255);
-background-color: rgb(0, 0, 0)</string>
+background-color: transparent</string>
    </property>
    <property name="text">
     <string/>

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -91,8 +91,8 @@ QWidget
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>280</y>
-     <width>281</width>
+     <y>260</y>
+     <width>291</width>
      <height>31</height>
     </rect>
    </property>

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -92,7 +92,7 @@ QWidget
     <rect>
      <x>20</x>
      <y>330</y>
-     <width>291</width>
+     <width>561</width>
      <height>31</height>
     </rect>
    </property>

--- a/tk_core_update.sh
+++ b/tk_core_update.sh
@@ -56,7 +56,7 @@ cp -R $DEST_REPO/* $DEST
 rm -rf $DEST/tests
 rm -rf $DEST/docs
 
-sed -i $DEST/info.yml -e "s/version: \"HEAD\"/version: \"$1\"/" 
+sed -i $DEST/info.yml -e "s/version: \"HEAD\"/version: \"$1\"/"
 
 cp python/tk-core/software_credits software_credits
 git add software_credits


### PR DESCRIPTION
This pr resize the splash.ui message box geometry to (20x260) 291x31 and replacing the message box background color to transparent in order to leave enough room for progress updates. 


![Screen Shot 2022-03-31 at 10 26 57 AM](https://user-images.githubusercontent.com/42726133/161093553-16b7d90a-11af-4e75-88ac-cb74cf566cf6.png)

