### PR TITLE
Add loader param when calling yaml.load method avoiding warning messages

### DIFF
--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -68,7 +68,7 @@ def get_location(app_bootstrap):
     # Read the location.yml file.
     with open(location, "r") as location_file:
         # If the file is empty, we're in dev mode.
-        return yaml.load(location_file) or dev_descriptor
+        return yaml.load(location_file, Loader=yaml.FullLoader) or dev_descriptor
 
 
 def get_startup_descriptor(sgtk, sg, app_bootstrap):


### PR DESCRIPTION
This PR remove some warning messages when calling load method of yaml lib.

```
$SHOTGUN_HOME/desktop/install/app_store/tk-framework-desktopstartup/v2.1.12/python/shotgun_desktop/location.py:71: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(location_file) or dev_descriptor

```
