### PR TITLE
SG-13621 Improved Error Message for Desktop when Pipeline Configuration Entity is disabled.

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -895,11 +895,6 @@ def main(**kwargs):
         ShotgunSamlUser,
     )
 
-    sys.path.append(r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
-    import pydevd
-
-    pydevd.settrace("localhost", port=5490, stdoutToServer=True, stderrToServer=True)
-
     try:
         # Reading user settings from disk.
         settings = sgtk.util.UserSettings()

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -734,9 +734,9 @@ def __handle_unexpected_exception(
             "Error: {error}\n"
             "For more information, see the log file at {log}.".format(
                 link=(
-                    "https://help.autodesk.com/view/SGSUB/ENU/?"
-                    "guid=SG_Administrator_ar_site_configuration_ar_site_preferences_html"
-                    "#entities"
+                    "{shotgrid_base_url}/preferences".format(
+                        shotgrid_base_url=shotgun_authenticator.get_default_host()
+                    )
                 ),
                 error=str(error_message),
                 log=log_location,
@@ -894,6 +894,11 @@ def main(**kwargs):
         set_shotgun_authenticator_support_web_login,
         ShotgunSamlUser,
     )
+
+    sys.path.append(r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
+    import pydevd
+
+    pydevd.settrace("localhost", port=5490, stdoutToServer=True, stderrToServer=True)
 
     try:
         # Reading user settings from disk.

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -923,14 +923,6 @@ def main(**kwargs):
         else:
             logger.debug("Not using SSO")
 
-        sys.path.append(
-            r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg"
-        )
-        import pydevd
-
-        pydevd.settrace(
-            "localhost", port=5490, stdoutToServer=True, stderrToServer=True
-        )
         # Now that we are logged, we can proceed with launching the
         # application.
         exit_code = __launch_app(app, splash, user, app_bootstrap, settings)

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -708,20 +708,42 @@ def __handle_unexpected_exception(
         log_location = app_bootstrap.get_logfile_location()
 
     logger.exception("Fatal error, user will be logged out.")
-    DesktopMessageBox.critical(
-        "ShotGrid Desktop Error",
-        "Something went wrong in the ShotGrid Desktop! If you <a href={link}>contact us</a> "
-        "we'll help you diagnose the issue.\n"
-        "Error: {error}\n"
-        "For more information, see the log file at {log}.".format(
-            link=sgtk.support_url,
-            error=str(error_message),
-            log=log_location,
-        ),
-        detailed_text="".join(
-            traceback.format_exception(exc_type, exc_value, exc_traceback)
-        ),
-    )
+
+    if (
+        'API read() invalid/missing string entity \'type\':\n{"type"=>"PipelineConfiguration"'
+        in str(error_message)
+    ):
+        DesktopMessageBox.critical(
+            "ShotGrid Desktop Error",
+            "PipelineConfiguration entities are not enabled for your site. "
+            "Head to your <a href={link}>Site Preferences</a>, enable them and try again.\n"
+            "Error: {error}\n"
+            "For more information, see the log file at {log}.".format(
+                link=(
+                    "https://help.autodesk.com/view/SGSUB/ENU/?"
+                    "guid=SG_Administrator_ar_site_configuration_ar_site_preferences_html"
+                    "#entities"
+                ),
+                error=str(error_message),
+                log=log_location,
+            ),
+        )
+
+    else:
+        DesktopMessageBox.critical(
+            "ShotGrid Desktop Error",
+            "Something went wrong in the ShotGrid Desktop! If you <a href={link}>contact us</a> "
+            "we'll help you diagnose the issue.\n"
+            "Error: {error}\n"
+            "For more information, see the log file at {log}.".format(
+                link=sgtk.support_url,
+                error=str(error_message),
+                log=log_location,
+            ),
+            detailed_text="".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            ),
+        )
     # If we are logged in, we should log out so the user is not stuck in a loop of always
     # automatically logging in each time the app is launched again
     if shotgun_authenticator:

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -655,13 +655,14 @@ def __ensure_engine_compatible_with_qt_version(engine, app_version):
 
 def _is_pipeline_config_disabled(error_message):
     """
-    Check if the PipelineConfiguration entities has been
+    Check if the 'PipelineConfiguration' entities has been
     disabled from the user site.
+
     :param error_message: The error string that will be displayed in a message box.
     :returns: True if the error message matches with the expected pipeline config
-              disabled message.
+          disabled message.
     """
-    # expected message when PipelineConfiguration entities has been
+    # expected error message when 'PipelineConfiguration' entities has been
     # disabled from the user site.
     pipeline_config_disabled_message = (
         "API read() invalid/missing string entity 'type':\n"

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -729,7 +729,7 @@ def __handle_unexpected_exception(
 
     if _is_pipeline_config_disabled(error_message):
         formatted_error_message = (
-            "PipelineConfiguration entities are not enabled for your site. "
+            "PipelineConfiguration entities are disabled for your site. "
             "Head to your <a href={link}>Site Preferences</a>, enable them and try again.\n"
             "Error: {error}\n"
             "For more information, see the log file at {log}.".format(

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -652,6 +652,7 @@ def __ensure_engine_compatible_with_qt_version(engine, app_version):
     if is_version_newer_or_equal(app_version, "v1.6.1"):
         raise EngineNotCompatibleWithDesktop16(app_version)
 
+
 def _is_pipeline_config_disabled(error_message):
     """
     Check if the PipelineConfiguration entities has been
@@ -663,10 +664,11 @@ def _is_pipeline_config_disabled(error_message):
     # expected message when PipelineConfiguration entities has been
     # disabled from the user site.
     pipeline_config_disabled_message = (
-        'API read() invalid/missing string entity \'type\':\n'
+        "API read() invalid/missing string entity 'type':\n"
         '{"type"=>"PipelineConfiguration"'
     )
     return pipeline_config_disabled_message in str(error_message)
+
 
 def _run_engine(engine, splash, startup_version, app_bootstrap, startup_desc, settings):
     __ensure_engine_compatible_with_qt_version(engine, app_bootstrap.get_version())
@@ -922,10 +924,13 @@ def main(**kwargs):
             logger.debug("Not using SSO")
 
         sys.path.append(
-            r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
+            r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg"
+        )
         import pydevd
-        pydevd.settrace('localhost', port=5490, stdoutToServer=True,
-                        stderrToServer=True)
+
+        pydevd.settrace(
+            "localhost", port=5490, stdoutToServer=True, stderrToServer=True
+        )
         # Now that we are logged, we can proceed with launching the
         # application.
         exit_code = __launch_app(app, splash, user, app_bootstrap, settings)


### PR DESCRIPTION
This PR handles the uncaught "API read()" exception raised when an user launches SG Desktop when PipelineConfiguration entities are disabled from the Site Preferences, also fix the error message displayed to the user.

![Screen Shot 2022-12-20 at 3 03 47 PM](https://user-images.githubusercontent.com/42726133/208763848-e63ea1a9-4abe-4d28-a2cf-3306d59ca338.png)
