### PR TITLE
Validate Python Version on Startup

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -553,7 +553,6 @@ def __start_engine_in_zero_config(app, app_bootstrap, splash, user):
     mgr = sgtk.bootstrap.ToolkitManager(user)
     # If we set 'SGTK_CONFIG_LOCK_VERSION' environment variable but
     # are running a python 3 interpreter, warn the user that this will have no effect.
-
     if (
         sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION in os.environ
         and sys.version_info[0] > 2

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -555,27 +555,24 @@ def __start_engine_in_zero_config(app, app_bootstrap, splash, user):
     # are running a python 3 interpreter, warn the user that this will have no effect.
 
     if (
-            sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION in os.environ
-            and sys.version_info[0] > 2
+        sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION in os.environ
+        and sys.version_info[0] > 2
     ):
         DesktopMessageBox.critical(
             "ShotGrid Desktop Warning",
             "{constant} will have no effect because there's not Python 2 available version.\n".format(
                 constant=sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION
-            )
+            ),
         )
     # If we set 'SHOTGUN_PYTHON_VERSION' environment variable, but at this point
     # we are running in Python 3 we should warn the user that this will have no
     # effect as there is no Python 2 version available.
-    if (
-            str(os.environ.get('SHOTGUN_PYTHON_VERSION')) == "2"
-            and sys.version_info[0] > 2
-    ):
+    if str(os.environ.get("SHOTGUN_PYTHON_VERSION")) == "2" and sys.version_info[0] > 2:
         DesktopMessageBox.critical(
             "ShotGrid Desktop Warning",
             "{constant} will have no effect because there's not Python 2 available version.\n".format(
-                constant='SHOTGUN_PYTHON_VERSION'
-            )
+                constant="SHOTGUN_PYTHON_VERSION"
+            ),
         )
 
     # Allows to take over the site config to use with Desktop without impacting the projects

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -551,6 +551,32 @@ def __start_engine_in_zero_config(app, app_bootstrap, splash, user):
     import sgtk
 
     mgr = sgtk.bootstrap.ToolkitManager(user)
+    # If we set 'SGTK_CONFIG_LOCK_VERSION' environment variable but
+    # are running a python 3 interpreter, warn the user that this will have no effect.
+
+    if (
+            sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION in os.environ
+            and sys.version_info[0] > 2
+    ):
+        DesktopMessageBox.critical(
+            "ShotGrid Desktop Warning",
+            "{constant} will have no effect because there's not Python 2 available version.\n".format(
+                constant=sgtk.bootstrap.constants.SGTK_CONFIG_LOCK_VERSION
+            )
+        )
+    # If we set 'SHOTGUN_PYTHON_VERSION' environment variable, but at this point
+    # we are running in Python 3 we should warn the user that this will have no
+    # effect as there is no Python 2 version available.
+    if (
+            str(os.environ.get('SHOTGUN_PYTHON_VERSION')) == "2"
+            and sys.version_info[0] > 2
+    ):
+        DesktopMessageBox.critical(
+            "ShotGrid Desktop Warning",
+            "{constant} will have no effect because there's not Python 2 available version.\n".format(
+                constant='SHOTGUN_PYTHON_VERSION'
+            )
+        )
 
     # Allows to take over the site config to use with Desktop without impacting the projects
     # configurations.


### PR DESCRIPTION
This PR add two warnings to validate Python version at the SG Desktop startup, this is useful to warn the user when using the environment variable 'SHOTGUN_PYTHON_VERSION' set to '2' to run a  Python 2 interpreter, but the version of SG Desktop installed does not support Python 2, it also applies in the case that a user is using the new environment variable 'SGTK_CONFIG_LOCK_VERSION' and the version of SG Desktop installed does not support Python 2 versions.

NOTE: This PR  makes use of the constant 'SGTK_CONFIG_LOCK_VERSION' which will be introduced in the new version of tk-core v0.20.15, so we'll first need to update the tk-core tag to this repository for this to work correctly.