### PR TITLE
SG-29529 'module' object has no attribute 'FullLoader'

### DIFF
--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -68,7 +68,7 @@ def get_location(app_bootstrap):
     # Read the location.yml file.
     with open(location, "r") as location_file:
         # If the file is empty, we're in dev mode.
-        return yaml.load(location_file, Loader=yaml.FullLoader) or dev_descriptor
+        return yaml.load(location_file) or dev_descriptor
 
 
 def get_startup_descriptor(sgtk, sg, app_bootstrap):


### PR DESCRIPTION
Remove Loader parameter in load method of pyyaml to guarantee backwards compatibility with python 2.