### PR TITLE
SG-30793 Prioritize User-Restricted Pipeline Configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,4 +40,4 @@ variables:
 jobs:
 - template: build-pipeline.yml@templates
   parameters:
-    skip_tests: true
+    skip_tests: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,5 +39,3 @@ variables:
 
 jobs:
 - template: build-pipeline.yml@templates
-  parameters:
-    skip_tests: false

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -115,7 +115,7 @@ def get_pipeline_configuration_info(connection):
             pcs = restricted_pcs
         elif unrestricted_pcs:
             pcs = unrestricted_pcs
-        else: 
+        else:
             pcs = []
 
         # Pick the last configuration (lowest id), if any.

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -113,10 +113,8 @@ def get_pipeline_configuration_info(connection):
 
         if restricted_pcs:
             pcs = restricted_pcs
-        elif unrestricted_pcs:
-            pcs = unrestricted_pcs
         else:
-            pcs = []
+            pcs = unrestricted_pcs
 
         # Pick the last configuration (lowest id), if any.
         if pcs:

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -108,18 +108,19 @@ def get_pipeline_configuration_info(connection):
         for p in pcs:
             if not p.get("users"):
                 unrestricted_pcs.append(p)
-                continue
-            for restricted_user in p.get("users"):
-                if logged_user_id == restricted_user.get("id"):
-                    restricted_pcs.append(p)
+            elif logged_user_id in [ u.get("id") for u in p.get("users") ]:
+                restricted_pcs.append(p)
 
         if restricted_pcs:
             pcs = restricted_pcs
-        else:
+        elif unrestricted_pcs:
             pcs = unrestricted_pcs
+        else: 
+            pcs = []
 
-        # Pick the last configuration (lowest id).
-        pc = pcs[-1]
+        # Pick the last configuration (lowest id), if any.
+        if pcs:
+            pc = pcs[-1]
 
         # It is possible to get multiple pipeline configurations due to user error.
         # Log a warning if there was more than one pipeline configuration found.

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -101,10 +101,12 @@ def get_pipeline_configuration_info(connection):
 
     pc = None
     if len(pcs) != 0:
-        # Pick the pipeline configuration with user restrictions, if any.
+        # Pick the pipeline configuration with restricted to user, if any.
+        logged_user_id = sgtk.get_authenticated_user().resolve_entity().get("id")
         for p in pcs:
-            if len(p.get("users")) != 0:
-                pc = p
+            for restricted_user in p.get("users"):
+                if logged_user_id == restricted_user.get("id"):
+                    pc = p
 
         # If not, pick the last (lowest id).
         if not pc:

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -108,7 +108,7 @@ def get_pipeline_configuration_info(connection):
         for p in pcs:
             if not p.get("users"):
                 unrestricted_pcs.append(p)
-            elif logged_user_id in [ u.get("id") for u in p.get("users") ]:
+            elif logged_user_id in [u.get("id") for u in p.get("users")]:
                 restricted_pcs.append(p)
 
         if restricted_pcs:

--- a/python/shotgun_desktop/paths.py
+++ b/python/shotgun_desktop/paths.py
@@ -45,6 +45,7 @@ def get_pipeline_configuration_info(connection):
         "project",
         "sg_plugin_ids",
         "plugin_ids",
+        "users",
     ]
 
     # Find the right pipeline configuration. We'll always pick a projectless
@@ -98,11 +99,17 @@ def get_pipeline_configuration_info(connection):
     )
     logger.debug(pprint.pformat(pcs))
 
-    if len(pcs) == 0:
-        pc = None
-    else:
-        # Pick the last result. See the big comment before the Shotgun query to understand.
-        pc = pcs[-1]
+    pc = None
+    if len(pcs) != 0:
+        # Pick the pipeline configuration with user restrictions, if any.
+        for p in pcs:
+            if len(p.get("users")) != 0:
+                pc = p
+
+        # If not, pick the last (lowest id).
+        if not pc:
+            pc = pcs[-1]
+
         # It is possible to get multiple pipeline configurations due to user error.
         # Log a warning if there was more than one pipeline configuration found.
         if len(pcs) > 1:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,7 +20,7 @@ from shotgun_desktop import paths
 
 
 class DummyConnection:
-    """Simulates the Shotgun class from python_api."""
+    """Simulate the Shotgun class from python_api."""
 
     def __init__(self, **kwargs):
         self.base_url = ""
@@ -38,8 +38,16 @@ class DummyConnection:
     return_value=[
         {
             "type": "PipelineConfiguration",
+            "id": 3,
+            "code": "restricted2",
+            "project": None,
+            "plugin_ids": None,
+            "users": [{"id": 88, "name": "HumanName", "type": "HumanUser"}],
+        },
+        {
+            "type": "PipelineConfiguration",
             "id": 2,
-            "code": "restricted",
+            "code": "restricted1",
             "project": None,
             "plugin_ids": None,
             "users": [{"id": 88, "name": "HumanName", "type": "HumanUser"}],
@@ -60,14 +68,14 @@ class DummyConnection:
 )
 def test_select_restricted_config(*mocks):
     """
-    Ensures that user-restricted configuration is selected over non-restricted
-    configuration if that user logs in.
+    Ensure that user-restricted configuration with lowest id is selected over
+    non-restricted configuration when that user logs in.
     """
     _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
     expected_pc = {
         "type": "PipelineConfiguration",
         "id": 2,
-        "code": "restricted",
+        "code": "restricted1",
         "project": None,
         "plugin_ids": None,
         "users": [{"id": 88, "name": "HumanName", "type": "HumanUser"}],
@@ -81,8 +89,16 @@ def test_select_restricted_config(*mocks):
     return_value=[
         {
             "type": "PipelineConfiguration",
+            "id": 3,
+            "code": "non-restricted2",
+            "project": None,
+            "plugin_ids": None,
+            "users": [],
+        },
+        {
+            "type": "PipelineConfiguration",
             "id": 2,
-            "code": "Secondary",
+            "code": "non-restricted1",
             "project": None,
             "plugin_ids": None,
             "users": [],
@@ -90,10 +106,10 @@ def test_select_restricted_config(*mocks):
         {
             "type": "PipelineConfiguration",
             "id": 1,
-            "code": "Primary",
+            "code": "restricted",
             "project": None,
             "plugin_ids": None,
-            "users": [],
+            "users": [{"id": 80, "name": "HumanName", "type": "HumanUser"}],
         },
     ],
 )
@@ -103,14 +119,14 @@ def test_select_restricted_config(*mocks):
 )
 def test_no_restricted_config(*mocks):
     """
-    Ensures that the configuration with the lowest id is selected if there are
-    no user restrictions.
+    Ensure that the configuration with the lowest id and without any user
+    restrictions is selected if there are no configurations restricting the user.
     """
     _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
     expected_pc = {
         "type": "PipelineConfiguration",
-        "id": 1,
-        "code": "Primary",
+        "id": 2,
+        "code": "non-restricted1",
         "project": None,
         "plugin_ids": None,
         "users": [],
@@ -120,7 +136,6 @@ def test_no_restricted_config(*mocks):
 
 @patch.object(DummyConnection, "find", return_value=[])
 def test_no_pipeline_config(*mocks):
-    """
-    Ensures that no configuration is returned if there aren't any supplied."""
+    """Ensure that no configuration is returned if there aren't any supplied."""
     _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
     assert not pc

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -149,28 +149,25 @@ def test_no_config_match(*mocks):
     But none of them are matching our user
     """
 
-    with \
-        patch.object(
-            DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
-        ), \
-        patch.object(
-            DummyConnection,
-            "find",
-            return_value=[
-                {
-                    "type": "PipelineConfiguration",
-                    "id": 1,
-                    "code": "pc1",
-                    "users": [{"id": 2, "type": "HumanUser"}],
-                },
-                {
-                    "type": "PipelineConfiguration",
-                    "id": 2,
-                    "code": "pc2",
-                    "users": [{"id": 2, "type": "HumanUser"}],
-                },
-            ],
-        ) \
-    :
+    with patch.object(
+        DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
+    ), patch.object(
+        DummyConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [{"id": 2, "type": "HumanUser"}],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [{"id": 2, "type": "HumanUser"}],
+            },
+        ],
+    ):
         _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
         assert pc is None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sys
+import os
+
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python/tk-core/python"))
+from python.shotgun_desktop import paths
+
+# sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+# import sgtk
+
+
+class Dummy:
+    def __init__(self, **kwargs):
+        self.base_url = ""
+
+    def find(self, *args, **kwargs):
+        pass
+
+    def resolve_entity(self, *args, **kwargs):
+        pass
+
+
+@patch.object(Dummy,"find",
+        return_value=[{'type': 'PipelineConfiguration', 'id': 2, 'code': 'restricted', 'project': None, 'plugin_ids': None, 'users': [{'id': 88, 'name': 'HumanName', 'type': 'HumanUser'}]},
+                      {'type': 'PipelineConfiguration', 'id': 1, 'code': 'non-restricted', 'project': None, 'plugin_ids': None, 'users': []}])
+@patch("sgtk.get_authenticated_user",
+       return_value=Dummy())
+@patch.object(Dummy,"resolve_entity",
+        return_value={'type': 'HumanUser', 'id': 88})
+def test_select_restricted_config(*mocks):
+    _, pc, _ = paths.get_pipeline_configuration_info(Dummy())
+    expected_pc = {'type': 'PipelineConfiguration', 'id': 2, 'code': 'restricted', 'project': None, 'plugin_ids': None, 'users': [{'id': 88, 'name': 'HumanName', 'type': 'HumanUser'}]}
+    assert pc == expected_pc
+
+
+@patch.object(Dummy,"find",
+        return_value=[{'type': 'PipelineConfiguration', 'id': 2, 'code': 'Secondary', 'project': None, 'plugin_ids': None, 'users': []}, 
+                      {'type': 'PipelineConfiguration', 'id': 1, 'code': 'Primary', 'project': None, 'plugin_ids': None, 'users': []}])
+@patch("sgtk.get_authenticated_user",
+       return_value=Dummy())
+@patch.object(Dummy,"resolve_entity",
+        return_value={'type': 'HumanUser', 'id': 88})
+def test_no_restricted_config(*mocks):
+    _, pc, _ = paths.get_pipeline_configuration_info(Dummy())
+    expected_pc = {'type': 'PipelineConfiguration', 'id': 1, 'code': 'Primary', 'project': None, 'plugin_ids': None, 'users': []}
+    assert pc == expected_pc
+
+
+@patch.object(Dummy,"find",
+        return_value=[])
+def test_no_pipeline_config(*mocks):
+    _, pc, _ = paths.get_pipeline_configuration_info(Dummy())
+    assert not pc

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -75,7 +75,7 @@ def test_one_pipeline_configuration(*mocks):
 def test_two_pipeline_configurations(*mocks):
     """
     Two configurations, no user restriction
-    We select the last one
+    We select the one with lowest id
     """
     with patch.object(
         MockConnection,
@@ -83,20 +83,20 @@ def test_two_pipeline_configurations(*mocks):
         return_value=[
             {
                 "type": "PipelineConfiguration",
-                "id": 1,
-                "code": "pc1",
+                "id": 2,
+                "code": "pc2",
                 "users": [],
             },
             {
                 "type": "PipelineConfiguration",
-                "id": 2,
-                "code": "pc2",
+                "id": 1,
+                "code": "pc1",
                 "users": [],
             },
         ],
     ):
         _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
-        assert pc["id"] == 2 and pc["code"] == "pc2"
+        assert pc["id"] == 1 and pc["code"] == "pc1"
 
 
 @patch("sgtk.get_authenticated_user", return_value=MockUser())
@@ -146,6 +146,12 @@ def test_user_restriction(*mocks):
         return_value=[
             {
                 "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [],
+            },
+            {
+                "type": "PipelineConfiguration",
                 "id": 1,
                 "code": "pc1",
                 "users": [
@@ -153,12 +159,6 @@ def test_user_restriction(*mocks):
                     {"id": 2, "type": "HumanUser"},
                     {"id": 3, "type": "HumanUser"},
                 ],
-            },
-            {
-                "type": "PipelineConfiguration",
-                "id": 2,
-                "code": "pc2",
-                "users": [],
             },
         ],
     ):
@@ -201,15 +201,15 @@ def test_user_restriction_no_match_fallback_unrestricted(*mocks):
         return_value=[
             {
                 "type": "PipelineConfiguration",
-                "id": 1,
-                "code": "pc1",
-                "users": [{"id": 2, "type": "HumanUser"}],
-            },
-            {
-                "type": "PipelineConfiguration",
                 "id": 2,
                 "code": "pc2",
                 "users": [],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [{"id": 2, "type": "HumanUser"}],
             },
         ],
     ):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,7 +10,6 @@
 
 import sys
 import os
-
 from unittest.mock import patch
 
 sys.path.insert(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,8 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
 import os
+import sys
 from unittest.mock import patch
 
 sys.path.insert(
@@ -19,8 +19,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
 from shotgun_desktop import paths
 
 
-class DummyConnection:
-    """Simulate the Shotgun class from python_api."""
+class MockUser:
+    """Mock a SG User class"""
+
+    def resolve_entity(self, *args, **kwargs):
+        pass
+
+
+class MockConnection:
+    """Mock the Shotgun class from python_api."""
 
     def __init__(self, **kwargs):
         self.base_url = ""
@@ -28,20 +35,198 @@ class DummyConnection:
     def find(self, *args, **kwargs):
         pass
 
-    def resolve_entity(self, *args, **kwargs):
-        pass
+
+def test_no_pipeline_config(*mocks):
+    """Ensure that no configuration is returned if there aren't any supplied."""
+    with patch.object(MockConnection, "find", return_value=[]):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc is None
 
 
-@patch("sgtk.get_authenticated_user", return_value=DummyConnection())
-def test_select_restricted_config(*mocks):
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1})
+def test_one_pipeline_configuration(*mocks):
+    """
+    Just one configuration, no user restriction
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc == {
+            "type": "PipelineConfiguration",
+            "id": 1,
+            "code": "pc1",
+            "users": [],
+        }
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1})
+def test_two_pipeline_configurations(*mocks):
+    """
+    Two configurations, no user restriction
+    We select the last one
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc["id"] == 2 and pc["code"] == "pc2"
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1})
+def test_lowest_id(*mocks):
+    """
+    Ensure that the configuration with the lowest id and without any user
+    restrictions is selected if there are no configurations restricting the user.
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 3,
+                "code": "pc3",
+                "users": [],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc["id"] == 1 and pc["code"] == "pc1"
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 2})
+def test_user_restriction(*mocks):
+    """
+    2 Configs: one is user restricted, one has no restriction
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [
+                    {"id": 1, "type": "HumanUser"},
+                    {"id": 2, "type": "HumanUser"},
+                    {"id": 3, "type": "HumanUser"},
+                ],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc["id"] == 1 and pc["code"] == "pc1"
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1})
+def test_user_restriction_all_restricted_different_users(*mocks):
+    """
+    Ensure that no configuration is returned if all have user restrictions,
+    but none match the user.
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [{"id": 2, "type": "HumanUser"}],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc is None
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+@patch.object(MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1})
+def test_user_restriction_no_match_fallback_unrestricted(*mocks):
+    """
+    2 Configs: one is user restricted, one has no restriction
+    """
+    with patch.object(
+        MockConnection,
+        "find",
+        return_value=[
+            {
+                "type": "PipelineConfiguration",
+                "id": 1,
+                "code": "pc1",
+                "users": [{"id": 2, "type": "HumanUser"}],
+            },
+            {
+                "type": "PipelineConfiguration",
+                "id": 2,
+                "code": "pc2",
+                "users": [],
+            },
+        ],
+    ):
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc["id"] == 2 and pc["code"] == "pc2"
+
+
+@patch("sgtk.get_authenticated_user", return_value=MockUser())
+def test_user_restriction_lowest_id(*mocks):
     """
     Ensure that user-restricted configuration with lowest id is selected over
     non-restricted configuration when that user logs in.
     """
     with patch.object(
-        DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
+        MockUser, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
     ), patch.object(
-        DummyConnection,
+        MockConnection,
         "find",
         return_value=[
             {
@@ -64,90 +249,5 @@ def test_select_restricted_config(*mocks):
             },
         ],
     ):
-        _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
-        expected_pc = {
-            "type": "PipelineConfiguration",
-            "id": 2,
-            "code": "restricted1",
-            "users": [{"id": 1, "name": "HumanName", "type": "HumanUser"}],
-        }
-        assert pc == expected_pc
-
-
-@patch("sgtk.get_authenticated_user", return_value=DummyConnection())
-def test_no_restricted_config(*mocks):
-    """
-    Ensure that the configuration with the lowest id and without any user
-    restrictions is selected if there are no configurations restricting the user.
-    """
-    with patch.object(
-        DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
-    ), patch.object(
-        DummyConnection,
-        "find",
-        return_value=[
-            {
-                "type": "PipelineConfiguration",
-                "id": 3,
-                "code": "non-restricted2",
-                "users": [],
-            },
-            {
-                "type": "PipelineConfiguration",
-                "id": 2,
-                "code": "non-restricted1",
-                "users": [],
-            },
-            {
-                "type": "PipelineConfiguration",
-                "id": 1,
-                "code": "restricted",
-                "users": [{"id": 2, "name": "HumanName", "type": "HumanUser"}],
-            },
-        ],
-    ):
-        _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
-        expected_pc = {
-            "type": "PipelineConfiguration",
-            "id": 2,
-            "code": "non-restricted1",
-            "users": [],
-        }
-        assert pc == expected_pc
-
-
-def test_no_pipeline_config(*mocks):
-    """Ensure that no configuration is returned if there aren't any supplied."""
-    with patch.object(DummyConnection, "find", return_value=[]):
-        _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
-        assert not pc
-
-
-@patch("sgtk.get_authenticated_user", return_value=DummyConnection())
-def test_no_config_match(*mocks):
-    """
-    Ensure that no configuration is returned if all have user restrictions,
-    but none match the user.
-    """
-    with patch.object(
-        DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
-    ), patch.object(
-        DummyConnection,
-        "find",
-        return_value=[
-            {
-                "type": "PipelineConfiguration",
-                "id": 1,
-                "code": "pc1",
-                "users": [{"id": 2, "type": "HumanUser"}],
-            },
-            {
-                "type": "PipelineConfiguration",
-                "id": 2,
-                "code": "pc2",
-                "users": [{"id": 2, "type": "HumanUser"}],
-            },
-        ],
-    ):
-        _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
-        assert pc is None
+        _, pc, _ = paths.get_pipeline_configuration_info(MockConnection())
+        assert pc["id"] == 2 and pc["code"] == "restricted1"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -139,3 +139,38 @@ def test_no_pipeline_config(*mocks):
     """Ensure that no configuration is returned if there aren't any supplied."""
     _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
     assert not pc
+
+
+@patch("sgtk.get_authenticated_user", return_value=DummyConnection())
+def test_no_config_match(*mocks):
+    """
+    The server has multiple Pipeline Configurations.
+    All of them have user restrictions
+    But none of them are matching our user
+    """
+
+    with \
+        patch.object(
+            DummyConnection, "resolve_entity", return_value={"type": "HumanUser", "id": 1}
+        ), \
+        patch.object(
+            DummyConnection,
+            "find",
+            return_value=[
+                {
+                    "type": "PipelineConfiguration",
+                    "id": 1,
+                    "code": "pc1",
+                    "users": [{"id": 2, "type": "HumanUser"}],
+                },
+                {
+                    "type": "PipelineConfiguration",
+                    "id": 2,
+                    "code": "pc2",
+                    "users": [{"id": 2, "type": "HumanUser"}],
+                },
+            ],
+        ) \
+    :
+        _, pc, _ = paths.get_pipeline_configuration_info(DummyConnection())
+        assert pc is None


### PR DESCRIPTION
If there are two site-wide pipeline configurations and a user with restrictions on one pipeline logs in, the pipeline with that user's restrictions will be prioritized. 