### PR TITLE
SG-31059 Prevent Desktopstartup Auto Update When Running On Python2

### DIFF
--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -80,10 +80,11 @@ def get_startup_descriptor(sgtk, sg, app_bootstrap):
     # Use the old API to create the descriptor, as we might be using a 0.16-based core.
     return sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(), # ~/Library/Caches/Shotgun/desktop
+        app_bootstrap.get_shotgun_desktop_cache_location(),  # ~/Library/Caches/Shotgun/desktop
         os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
         get_location(app_bootstrap),
     )
+
 
 def get_latest_py2_descriptor(sgtk, sg, app_bootstrap):
     """
@@ -100,10 +101,11 @@ def get_latest_py2_descriptor(sgtk, sg, app_bootstrap):
     # Use the old API to create the descriptor, as we might be using a 0.16-based core.
     return sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(), # ~/Library/Caches/Shotgun/desktop
+        app_bootstrap.get_shotgun_desktop_cache_location(),  # ~/Library/Caches/Shotgun/desktop
         os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
         startup_py2_version,
     )
+
 
 def write_location(descriptor):
     """

--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -80,30 +80,9 @@ def get_startup_descriptor(sgtk, sg, app_bootstrap):
     # Use the old API to create the descriptor, as we might be using a 0.16-based core.
     return sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(),  # ~/Library/Caches/Shotgun/desktop
+        app_bootstrap.get_shotgun_desktop_cache_location(),  
         os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
         get_location(app_bootstrap),
-    )
-
-
-def get_latest_py2_descriptor(sgtk, sg, app_bootstrap):
-    """
-    Creates a startup descriptor based on the current desktop startup supported
-    Python 2 version.
-
-    :returns: :class:`sgtk.descriptor.FrameworkDescriptor` instance.
-    """
-    startup_py2_version = {
-        "type": "app_store",
-        "name": "tk-framework-desktopstartup",
-        "version": "v2.1.12",
-    }
-    # Use the old API to create the descriptor, as we might be using a 0.16-based core.
-    return sgtk.deploy.descriptor.get_from_location_and_paths(
-        sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(),  # ~/Library/Caches/Shotgun/desktop
-        os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
-        startup_py2_version,
     )
 
 

--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -80,11 +80,30 @@ def get_startup_descriptor(sgtk, sg, app_bootstrap):
     # Use the old API to create the descriptor, as we might be using a 0.16-based core.
     return sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(),
+        app_bootstrap.get_shotgun_desktop_cache_location(), # ~/Library/Caches/Shotgun/desktop
         os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
         get_location(app_bootstrap),
     )
 
+def get_latest_py2_descriptor(sgtk, sg, app_bootstrap):
+    """
+    Creates a startup descriptor based on the current desktop startup supported
+    Python 2 version.
+
+    :returns: :class:`sgtk.descriptor.FrameworkDescriptor` instance.
+    """
+    startup_py2_version = {
+        "type": "app_store",
+        "name": "tk-framework-desktopstartup",
+        "version": "v2.1.12",
+    }
+    # Use the old API to create the descriptor, as we might be using a 0.16-based core.
+    return sgtk.deploy.descriptor.get_from_location_and_paths(
+        sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
+        app_bootstrap.get_shotgun_desktop_cache_location(), # ~/Library/Caches/Shotgun/desktop
+        os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
+        startup_py2_version,
+    )
 
 def write_location(descriptor):
     """

--- a/python/shotgun_desktop/location.py
+++ b/python/shotgun_desktop/location.py
@@ -80,7 +80,7 @@ def get_startup_descriptor(sgtk, sg, app_bootstrap):
     # Use the old API to create the descriptor, as we might be using a 0.16-based core.
     return sgtk.deploy.descriptor.get_from_location_and_paths(
         sgtk.deploy.descriptor.AppDescriptor.FRAMEWORK,
-        app_bootstrap.get_shotgun_desktop_cache_location(),  
+        app_bootstrap.get_shotgun_desktop_cache_location(),
         os.path.join(app_bootstrap.get_shotgun_desktop_cache_location(), "install"),
         get_location(app_bootstrap),
     )

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -9,11 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-from shotgun_desktop.location import (
-    write_location,
-    get_startup_descriptor,
-    get_latest_py2_descriptor,
-)
+import os
+from shotgun_desktop.location import write_location, get_startup_descriptor
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
 from sgtk.descriptor import CheckVersionConstraintsError
 
@@ -34,21 +31,19 @@ def _supports_get_from_location_and_paths(sgtk):
     """
     return hasattr(sgtk.deploy.descriptor, "get_from_location_and_paths")
 
-
-def _latest_descriptor(sgtk, sg, app_bootstrap, current_desc):
-    """"""
+def _out_of_date_check(latest_descriptor, current_desc):
+    """Check if the version is out of date."""
+    location = current_desc.get_path()
     # Check if we're running in Python 2
-    if sys.version_info[0] < 3:
-        # This will create the descriptor for desktopstartup supported
-        # Python 2 version
-        return get_latest_py2_descriptor(sgtk, sg, app_bootstrap)
-    try:
-        latest_descriptor = current_desc.find_latest_version()
-    except Exception as e:
-        logger.exception("Could not access the TK App Store (tank.shotgunstudio.com):")
+    if (
+            sys.version_info[0] < 3 and
+            os.path.exists(location)
+    ):
+        logger.debug(
+            "Desktop startup is Currently running version %s" % current_desc.get_version(),
+        )
         return False
-    return latest_descriptor
-
+    return not latest_descriptor.get_version() != current_desc.get_version()  # 2.1.12 != 2.1.21 True
 
 def upgrade_startup(splash, sgtk, app_bootstrap):
     """
@@ -86,14 +81,10 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
         splash.set_message("Getting ShotGrid Desktop updates...")
         logger.info("Getting ShotGrid Desktop updates...")
 
-    # Retrieve the latest startup descriptor
-    latest_descriptor = _latest_descriptor(sgtk, sg, app_bootstrap, current_desc)
-    logger.debug("Testing for remote access: %s", latest_descriptor)
-
-    if not latest_descriptor.has_remote_access():
-        logger.info(
-            "Could not update %r: remote access not available.", latest_descriptor
-        )
+    try:
+        latest_descriptor = current_desc.find_latest_version()
+    except Exception as e:
+        logger.exception("Could not access the TK App Store (tank.shotgunstudio.com):")
         return False
 
     # check deprecation
@@ -107,15 +98,8 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
         return False
 
     # out of date check
-    out_of_date = latest_descriptor.get_version() != current_desc.get_version()
+    out_of_date = _out_of_date_check(latest_descriptor, current_desc)
     logger.debug("version is out of date: %s", out_of_date)
-    logger.debug(
-        "Desktop startup is Currently running version %s" % current_desc.get_version(),
-    )
-    logger.debug(
-        "And the Python2 supported version of the startup is: %s"
-        % latest_descriptor.get_version(),
-    )
     if not out_of_date:
         logger.debug(
             "Desktop startup is up to date. Currently running version %s"

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -33,10 +33,22 @@ def _supports_get_from_location_and_paths(sgtk):
 
 
 def _out_of_date_check(latest_descriptor, current_desc):
-    """Check if the version is out of date."""
-    location = current_desc.get_path()
-    # Check if we're running in Python 2
-    if sys.version_info[0] < 3 and os.path.exists(location):
+    """
+    Check if the version is out of date, this prevents an upgrade of the startup logic
+    in the event that it detects SG Desktop is running on Python 2.
+
+    :param latest_descriptor:`sgtk.descriptor.FrameworkDescriptor` instance with the latest startup descriptor.
+    :param current_desc:`sgtk.descriptor.FrameworkDescriptor` instance with the current startup descriptor.
+
+    :returns: True if the startup version is outdated  update was downloaded and the descriptor updated, False otherwise.
+    """
+
+    # If we're running in Python 2 and if the bundled framework exists on disk,
+    # returns False to avoid upgrade the startup logic.
+    if sys.version_info[0] < 3 and os.path.exists(current_desc.get_path()):
+        logger.debug(
+            "Using Python version '%s'" % ".".join(str(i) for i in sys.version_info[0:3])
+        )
         logger.debug(
             "Desktop startup is Currently running version %s"
             % current_desc.get_version(),

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -9,7 +9,11 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-from shotgun_desktop.location import write_location, get_startup_descriptor, get_latest_py2_descriptor
+from shotgun_desktop.location import (
+    write_location,
+    get_startup_descriptor,
+    get_latest_py2_descriptor,
+)
 from shotgun_desktop.desktop_message_box import DesktopMessageBox
 from sgtk.descriptor import CheckVersionConstraintsError
 
@@ -30,6 +34,7 @@ def _supports_get_from_location_and_paths(sgtk):
     """
     return hasattr(sgtk.deploy.descriptor, "get_from_location_and_paths")
 
+
 def _latest_descriptor(sgtk, sg, app_bootstrap, current_desc):
     """"""
     # Check if we're running in Python 2
@@ -43,6 +48,7 @@ def _latest_descriptor(sgtk, sg, app_bootstrap, current_desc):
         logger.exception("Could not access the TK App Store (tank.shotgunstudio.com):")
         return False
     return latest_descriptor
+
 
 def upgrade_startup(splash, sgtk, app_bootstrap):
     """
@@ -85,7 +91,9 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
     logger.debug("Testing for remote access: %s", latest_descriptor)
 
     if not latest_descriptor.has_remote_access():
-        logger.info("Could not update %r: remote access not available.", latest_descriptor)
+        logger.info(
+            "Could not update %r: remote access not available.", latest_descriptor
+        )
         return False
 
     # check deprecation
@@ -102,8 +110,7 @@ def upgrade_startup(splash, sgtk, app_bootstrap):
     out_of_date = latest_descriptor.get_version() != current_desc.get_version()
     logger.debug("version is out of date: %s", out_of_date)
     logger.debug(
-        "Desktop startup is Currently running version %s"
-        % current_desc.get_version(),
+        "Desktop startup is Currently running version %s" % current_desc.get_version(),
     )
     logger.debug(
         "And the Python2 supported version of the startup is: %s"

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -40,7 +40,8 @@ def _out_of_date_check(latest_descriptor, current_desc):
     :param latest_descriptor:`sgtk.descriptor.FrameworkDescriptor` instance with the latest startup descriptor.
     :param current_desc:`sgtk.descriptor.FrameworkDescriptor` instance with the current startup descriptor.
 
-    :returns: True if the startup version is outdated  update was downloaded and the descriptor updated, False otherwise.
+    :returns: True if the startup version is outdated in comparison with the latest available version on the
+              appstore. False otherwise.
     """
 
     # If we're running in Python 2 and if the bundled framework exists on disk,

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -47,7 +47,8 @@ def _out_of_date_check(latest_descriptor, current_desc):
     # returns False to avoid upgrade the startup logic.
     if sys.version_info[0] < 3 and os.path.exists(current_desc.get_path()):
         logger.debug(
-            "Using Python version '%s'" % ".".join(str(i) for i in sys.version_info[0:3])
+            "Using Python version '%s'"
+            % ".".join(str(i) for i in sys.version_info[0:3])
         )
         logger.debug(
             "Desktop startup is Currently running version %s"

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -42,9 +42,7 @@ def _out_of_date_check(latest_descriptor, current_desc):
             % current_desc.get_version(),
         )
         return False
-    return (
-        not latest_descriptor.get_version() != current_desc.get_version()
-    )
+    return latest_descriptor.get_version() != current_desc.get_version()
 
 
 def upgrade_startup(splash, sgtk, app_bootstrap):

--- a/python/shotgun_desktop/upgrade_startup.py
+++ b/python/shotgun_desktop/upgrade_startup.py
@@ -31,19 +31,21 @@ def _supports_get_from_location_and_paths(sgtk):
     """
     return hasattr(sgtk.deploy.descriptor, "get_from_location_and_paths")
 
+
 def _out_of_date_check(latest_descriptor, current_desc):
     """Check if the version is out of date."""
     location = current_desc.get_path()
     # Check if we're running in Python 2
-    if (
-            sys.version_info[0] < 3 and
-            os.path.exists(location)
-    ):
+    if sys.version_info[0] < 3 and os.path.exists(location):
         logger.debug(
-            "Desktop startup is Currently running version %s" % current_desc.get_version(),
+            "Desktop startup is Currently running version %s"
+            % current_desc.get_version(),
         )
         return False
-    return not latest_descriptor.get_version() != current_desc.get_version()  # 2.1.12 != 2.1.21 True
+    return (
+        not latest_descriptor.get_version() != current_desc.get_version()
+    )
+
 
 def upgrade_startup(splash, sgtk, app_bootstrap):
     """


### PR DESCRIPTION
This PR introduces a check to prevent the startup logic from being upgraded to the latest available version in the event that SG Desktop is running on Python2.