### PR TITLE
Add Python minor version to splash top right label

### DIFF
--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -885,7 +885,7 @@ def main(**kwargs):
 
     if is_version_newer_or_equal(app_bootstrap.get_version(), "v1.6.0"):
         splash.set_version(
-            "{} - Python {}".format(app_bootstrap.get_version(), sys.version_info[0])
+            f"{app_bootstrap.get_version()} - Python {sys.version_info[0]}.{sys.version_info[1]}"
         )
     else:
         splash.set_version(app_bootstrap.get_version())

--- a/python/shotgun_desktop/ui/splash.py
+++ b/python/shotgun_desktop/ui/splash.py
@@ -53,7 +53,7 @@ class Ui_Splash(object):
         self.message.setAlignment(QtCore.Qt.AlignLeading|QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
         self.message.setObjectName("message")
         self.version = QtGui.QLabel(Splash)
-        self.version.setGeometry(QtCore.QRect(480, 20, 101, 20))
+        self.version.setGeometry(QtCore.QRect(460, 30, 121, 30))
         self.version.setStyleSheet("color: rgb(255, 255, 255);\n"
 "background-color: rgb(0, 0, 0)")
         self.version.setText("")

--- a/resources/splash.ui
+++ b/resources/splash.ui
@@ -110,10 +110,10 @@ background-color: transparent</string>
   <widget class="QLabel" name="version">
    <property name="geometry">
     <rect>
-     <x>480</x>
-     <y>20</y>
-     <width>101</width>
-     <height>20</height>
+     <x>460</x>
+     <y>30</y>
+     <width>121</width>
+     <height>30</height>
     </rect>
    </property>
    <property name="styleSheet">


### PR DESCRIPTION
The splash screen shows the Python major version since #60. But not the minor version and this could be useful.

- Add Python minor version to splash top right label
- Add more space for the label to avoid looking _squished_



| Before   |      After      |
|----------|-------------|
| ![image](https://github.com/user-attachments/assets/70341084-d7e6-4c48-89dc-e066e1749bca) | ![image](https://github.com/user-attachments/assets/bd042fcf-610f-4931-9104-5ba187915f1e) |

