### PR TITLE
SG-30952 Drop support of SGD<1.8

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -30,8 +30,8 @@ description: "Startup logic for the PTR desktop app"
 # the update with this number here. If we dump this version here to something
 # more recent, then the update will fail to install since the descriptor
 # will complain that the current core is older than "requires_core_version".
-requires_core_version: "v0.16.0"
-requires_desktop_version: "v1.1.0"
+requires_core_version: "v0.21.6"
+requires_desktop_version: "v1.8.0"
 
 # the frameworks this framework requires
 frameworks:

--- a/python/shotgun_desktop/startup.py
+++ b/python/shotgun_desktop/startup.py
@@ -844,21 +844,6 @@ def main(**kwargs):
 
     global logger
 
-    # Older versions of the desktop on Windows logged at %APPDATA%\Shotgun\tk-desktop.log. Notify the user that
-    # this logging location is deprecated and the logs are now at %APPDATA%\Shotgun\Logs\tk-desktop.log
-    if sgtk.util.is_windows() and is_version_older_or_equal(
-        app_bootstrap.get_version(), "v1.3.6"
-    ):
-        logger.info(
-            "Logging at this location will now stop and resume at {0}\\tk-desktop.log".format(
-                sgtk.LogManager().log_folder
-            )
-        )
-        logger.info(
-            "If you see any more logs past this line, you need to upgrade your site configuration to "
-            "the latest core and apps using 'tank core' and 'tank updates'."
-        )
-
     # Core will take over logging
     app_bootstrap.tear_down_logging()
 
@@ -870,12 +855,9 @@ def main(**kwargs):
     # Create some ui related objects
     app, splash = __init_app()
 
-    if is_version_newer_or_equal(app_bootstrap.get_version(), "v1.6.0"):
-        splash.set_version(
-            f"{app_bootstrap.get_version()} - Python {sys.version_info[0]}.{sys.version_info[1]}"
-        )
-    else:
-        splash.set_version(app_bootstrap.get_version())
+    splash.set_version(
+        f"{app_bootstrap.get_version()} - Python {sys.version_info[0]}.{sys.version_info[1]}"
+    )
 
     # We might crash before even initializing the authenticator, so instantiate
     # it right away.


### PR DESCRIPTION
- Requires core version v0.21.6 (Clean-up Qt4)
- Requires desktop version v1.8.0 (Min supported version)
- Removes conditional logic for older/deprecated desktop versions