### PR TITLE
SG-30952 Relax core requirement

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -30,7 +30,7 @@ description: "Startup logic for the PTR desktop app"
 # the update with this number here. If we dump this version here to something
 # more recent, then the update will fail to install since the descriptor
 # will complain that the current core is older than "requires_core_version".
-requires_core_version: "v0.21.6"
+requires_core_version: "v0.20.16"
 requires_desktop_version: "v1.8.0"
 
 # the frameworks this framework requires


### PR DESCRIPTION
This will prevent this kind of warning

```
2025-04-16 09:31:38,073 [39746 WARNING sgtk.ext.shotgun_desktop.upgrade_startup] Cannot upgrade to the latest Desktop Startup v2.4.1. Requires at least Core API v0.21.6 but currently installed version is v0.20.16.
```